### PR TITLE
Strip the prefix path from the requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This is the priority of the rules type evaluation (top-down):
 - `path`: a path prefix, the matching evaluation will be performed whit and without the trailing slash, eg `/foo` will match `/foo` and `/foo/*`, also `/foo/` will match `/foo` and `/foo/*`
 - `lets_encrypt`: can be `true` or `false`, if set to `true` request a valid Let's Encrypt certificate, mandatory
 - `http2https` can be `true` or `false`, if set to `true` HTTP will be redirect to HTTPS, mandatory
+- `strip_prefix`: can be `true` or `false`, if set to `true` the prefix of the requested path will be stripped from the original request before sending it to the downstream server.
 
 ### Examples
 

--- a/imageroot/actions/delete-route/20writeconfig
+++ b/imageroot/actions/delete-route/20writeconfig
@@ -47,6 +47,7 @@ r = agent.redis_connect(privileged=True)
 prefix=f'{agent_id}/kv/http'
 router=f'{prefix}/routers/{data["instance"]}-http'
 router_s=f'{prefix}/routers/{data["instance"]}-https'
+middlewares=f'{prefix}/middlewares'
 
 # Setup HTTP ans HTTPS routers
 r.delete(f'{prefix}/services/{data["instance"]}/loadBalancer/servers/0/url')
@@ -62,3 +63,6 @@ r.delete(f'{router_s}/service')
 r.delete(f'{router_s}/tls/domains/0/main')
 r.delete(f'{router_s}/tls/certresolver')
 r.delete(f'{router}/middlewares/0')
+r.delete(f'{router}/middlewares/1')
+r.delete(f'{router_s}/middlewares/1')
+r.delete(f'{middlewares}/{data["instance"]}-stripprefix/stripPrefix/prefixes/0')

--- a/imageroot/actions/set-route/20writeconfig
+++ b/imageroot/actions/set-route/20writeconfig
@@ -46,6 +46,7 @@ r = agent.redis_connect(privileged=True)
 prefix=f'{agent_id}/kv/http'
 router=f'{prefix}/routers/{data["instance"]}-http'
 router_s=f'{prefix}/routers/{data["instance"]}-https'
+middlewares=f'{prefix}/middlewares'
 
 # Setup HTTP ans HTTPS routers
 r.set(f'{prefix}/services/{data["instance"]}/loadBalancer/servers/0/url', data["url"])
@@ -97,3 +98,9 @@ if data["http2https"]:
     r.set(f'{router}/middlewares/0', "http2https-redirectscheme")
 else:
     r.delete(f'{router}/middlewares/0')
+
+# Strip the path from the request
+if data.get("strip_prefix"):
+    r.set(f'{middlewares}/{data["instance"]}-stripprefix/stripPrefix/prefixes/0', f'{path}')
+    r.set(f'{router}/middlewares/1', f'{data["instance"]}-stripprefix')
+    r.set(f'{router_s}/middlewares/1', f'{data["instance"]}-stripprefix')

--- a/imageroot/actions/set-route/validate-input.json
+++ b/imageroot/actions/set-route/validate-input.json
@@ -40,7 +40,10 @@
     "dependencies": {
         "host": {
             "required": ["lets_encrypt"]
-        }
+        },
+	"strip_prefix": {
+	    "required": ["path"]
+	}
     },
     "properties": {
         "instance": {
@@ -81,6 +84,11 @@
             "type": "boolean",
             "title": "HTTP to HTTPS redirection",
             "description": "Redirect all the HTTP requests to HTTPS"
-        }
+        },
+	"strip_prefix": {
+	    "type": "boolean",
+	    "title": "Strip prefix path",
+	    "description": "Strip the path prefix from the request"
+	}
     }
 }


### PR DESCRIPTION
With the `strip_prefix` (boolean) option is possible to strip the
prefix of the requested path from the original request before sending
it to the downstream server.