### PR TITLE
Add APIs to get the status of the requested certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The module exposes 2 actions:
 - `list-routes`
 - `set-certificate`
 - `delete-certificate`
+- `list-certificates`
 
 ## set-route
 
@@ -150,4 +151,20 @@ The action takes 1 parameter:
 Example:
 ```
 api-cli run delete-certificate --agent module/traefik1 --data "{\"fqdn\": \"$(hostname -f)\""
+```
+
+## list-certificates
+
+This action returns a list of requested certificate, the list is an JSON array, and if no certificate was requested, an
+empty array is returned.
+The action takes no parameter:
+
+Example:
+```
+api-cli run list-certificates --agent module/traefik1
+```
+
+Output:
+```json
+["example.com"]
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The module exposes 2 actions:
 - `delete-route`
 - `list-routes`
 - `set-certificate`
+- `get-certificate`
 - `delete-certificate`
 - `list-certificates`
 
@@ -137,6 +138,23 @@ The action takes 1 parameter:
 Example:
 ```
 api-cli run set-certificate --agent module/traefik1 --data "{\"fqdn\": \"$(hostname -f)\""
+```
+
+## get-certificate
+
+Run this action to get the status of requested a Let's Encrypt certificate
+
+The action takes 1 parameter:
+- `fqdn`: the fqdn of the requested certificate
+
+Example:
+```
+api-cli run get-certificate --agent module/traefik1 --data "{\"fqdn\": \"$(hostname -f)\""
+```
+
+Output:
+```
+{"fqdn": "example.com", "obtained": true}
 ```
 
 ## delete-certificate

--- a/imageroot/actions/get-certificate/20readconfig
+++ b/imageroot/actions/get-certificate/20readconfig
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import json
+import os
+import agent
+import sys
+import re
+import urllib.request
+
+# Try to parse the stdin as JSON.
+# If parsing fails, output everything to stderr
+data = json.load(sys.stdin)
+fqdn = data['fqdn']
+certificate = {}
+
+api_path = os.environ["API_PATH"]
+moduleid = os.environ["MODULE_ID"]
+
+try:
+    # Get the certificate route from the API
+    with urllib.request.urlopen(f'http://127.0.0.1/{api_path}/api/http/routers/certificate-{fqdn}@redis') as res:
+        traefik_https_route = json.load(res)
+
+    # Open the certificates storage file
+    with open(f'/home/{moduleid}/.local/share/containers/storage/volumes/traefik-acme/_data/acme.json') as f:
+        acme_storage = json.load(f)
+
+    certificate['fqdn'] = fqdn
+
+    certificate['obtained'] = False
+
+    resolver = traefik_https_route['tls']['certResolver']
+
+    certificates = acme_storage[resolver].get('Certificates')
+
+    # Check if the certificate is present in the storage
+    for cert in certificates if certificates else []:
+        if cert['domain']['main'] == data['fqdn']:
+            certificate['obtained'] = True
+            break
+
+except urllib.error.HTTPError as e:
+    if e.code == 404:
+        # If the certificate is not found, return an empty JSON object
+        pass
+
+except urllib.error.URLError as e:
+    raise Exception(f'Error reaching traefik daemon: {e.reason}') from e
+
+json.dump(certificate, fp=sys.stdout)

--- a/imageroot/actions/get-certificate/validate-input.json
+++ b/imageroot/actions/get-certificate/validate-input.json
@@ -1,0 +1,22 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "get-certificate input",
+    "$id": "http://schema.nethserver.org/traefik/get-certificate-input.json",
+    "description": "Get status of a requested certificate",
+    "examples": [
+        {
+        "fqdn": "example.com"
+    }
+    ],
+    "type": "object",
+    "required": [
+        "fqdn"
+    ],
+    "properties": {
+        "fqdn": {
+            "type":"string",
+            "format": "hostname",
+            "title": "A fully qualified domain name"
+        }
+    }
+}

--- a/imageroot/actions/get-certificate/validate-output.json
+++ b/imageroot/actions/get-certificate/validate-output.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "get-certificate output",
+    "$id": "http://schema.nethserver.org/traefik/get-certificate-output.json",
+    "description": "Status of a requested certificate",
+    "examples": [
+        {
+        "fqdn": "example.com",
+	"obtained": "true"
+    }
+    ],
+    "type": "object",
+    "oneOf":[
+	    {
+		    "required": [
+			    "fqdn",
+			    "obtained"
+		    ]
+	    },
+	    {
+		    "properties": {},
+		    "additionalProperties": false
+	    }
+    ],
+    "properties": {
+        "fqdn": {
+            "type":"string",
+            "format": "hostname",
+            "title": "A fully qualified domain name"
+        },
+        "obtained": {
+            "type":"boolean",
+            "title": "true if the certificate was obtained correctly"
+        }
+
+    }
+}

--- a/imageroot/actions/list-certificates/20readconfig
+++ b/imageroot/actions/list-certificates/20readconfig
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import json
+import os
+import agent
+import sys
+import urllib.request
+
+
+api_path = os.environ["API_PATH"]
+
+# Get the list of routers keys
+try:
+    with urllib.request.urlopen(f'http://127.0.0.1/{api_path}/api/http/routers') as res:
+        traefik_routes = json.load(res)
+except urllib.error.URLError as e:
+    raise Exception(f'Error reaching traefik daemon: {e.reason}') from e
+
+# Gernerate the list of certificates
+routes = [ route['name'].removeprefix('certificate-').removesuffix('@redis') for route in traefik_routes
+        if route['name'].startswith('certificate-') and route['name'].endswith('@redis') ]
+
+json.dump(routes, fp=sys.stdout)

--- a/imageroot/actions/list-certificates/validate-output.json
+++ b/imageroot/actions/list-certificates/validate-output.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "list-certificates output",
+    "$id": "http://schema.nethserver.org/samba/list-certificates-output.json",
+    "description": "Return a list of requested certificates fqdn",
+    "examples": [
+	    ["example.com"],
+	    []
+    ],
+    "type": "array",
+    "items": {
+	    "type": "string",
+            "format": "hostname",
+            "title": "A fully qualified domain name"
+    }
+}

--- a/tests/20_traefik_certificates_api.robot
+++ b/tests/20_traefik_certificates_api.robot
@@ -1,0 +1,25 @@
+*** Settings ***
+Library    SSHLibrary
+Resource          api.resource
+
+*** Test Cases ***
+Request an invalid certificate
+    ${response} =  Run task    module/traefik1/set-certificate
+    ...    {"fqdn":"example.com"}
+
+Get invalid cerficate status
+    ${response} =  Run task    module/traefik1/get-certificate    {"fqdn": "example.com"}
+    Should Be Equal As Strings    ${response['fqdn']}        example.com
+    Should Be Equal As Strings    ${response['obtained']}    False
+
+Get certificate list
+    ${response} =  Run task    module/traefik1/list-certificates    {}
+    Should Contain    ${response}    example.com
+
+Delete certificate
+    Run task    module/traefik1/delete-certificate   	 {"fqdn": "example.com"}
+
+Get empty certificates list
+    Sleep    10s
+    ${response} =  Run task    module/traefik1/list-certificates    {}
+    Should Be Empty    ${response}


### PR DESCRIPTION
This PR will add two new APIs
- get-certificate`:  get the current status of a requested certificate
-  'list-certificates': get a list of the currently requested certificates

It Is also provided a new test suite for all the current get/set/list/delete certificates APIs
See the updated README for the full documentation.