### PR TITLE
Make `delete-*` and `set-*` APIs synchronous

### DIFF
--- a/imageroot/actions/delete-certificate/20writeconfig
+++ b/imageroot/actions/delete-certificate/20writeconfig
@@ -41,7 +41,7 @@ if not agent_id:
     raise Exception("AGENT_ID not found inside the environemnt")
 
 # Connect to redis
-rdb = agent.redis_connect(privileged=True)
+rdb = agent.redis_connect(privileged=True).pipeline()
 
 # Prepare common key prefix
 router=f'{agent_id}/kv/http/routers/certificate-{data["fqdn"]}'
@@ -54,6 +54,9 @@ rdb.delete(f'{router}/service')
 rdb.delete(f'{router}/tls')
 rdb.delete(f'{router}/tls/domains/0/main')
 rdb.delete(f'{router}/tls/certresolver')
+
+# Write the configuration on redis
+rdb.execute()
 
 # Output valid JSON
 print("true")

--- a/imageroot/actions/delete-certificate/21waitsync
+++ b/imageroot/actions/delete-certificate/21waitsync
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import json
+import sys
+import time
+from get_certificate import get_certificate
+
+data = json.load(sys.stdin)
+retry = 0
+
+while get_certificate(data).get('fqdn') == data['fqdn'] and retry <= 10:
+    retry += 1
+    time.sleep(1)

--- a/imageroot/actions/delete-route/20writeconfig
+++ b/imageroot/actions/delete-route/20writeconfig
@@ -41,7 +41,7 @@ if not agent_id:
     raise Exception("AGENT_ID not found inside the environemnt")
 
 # Connect to redis
-r = agent.redis_connect(privileged=True)
+r = agent.redis_connect(privileged=True).pipeline()
 
 # Prepare common key prefix
 prefix=f'{agent_id}/kv/http'
@@ -66,3 +66,6 @@ r.delete(f'{router}/middlewares/0')
 r.delete(f'{router}/middlewares/1')
 r.delete(f'{router_s}/middlewares/1')
 r.delete(f'{middlewares}/{data["instance"]}-stripprefix/stripPrefix/prefixes/0')
+
+# Write the configuration on redis
+r.execute()

--- a/imageroot/actions/delete-route/21waitsync
+++ b/imageroot/actions/delete-route/21waitsync
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import json
+import sys
+import time
+from get_route import get_route
+
+data = json.load(sys.stdin)
+retry = 0
+
+while get_route(data).get('instance') == data['instance'] and retry <= 10:
+    retry += 1
+    time.sleep(1)

--- a/imageroot/actions/get-certificate/20readconfig
+++ b/imageroot/actions/get-certificate/20readconfig
@@ -21,50 +21,10 @@
 #
 
 import json
-import os
-import agent
 import sys
-import re
-import urllib.request
+from get_certificate import get_certificate
 
 # Try to parse the stdin as JSON.
 # If parsing fails, output everything to stderr
-data = json.load(sys.stdin)
-fqdn = data['fqdn']
-certificate = {}
 
-api_path = os.environ["API_PATH"]
-moduleid = os.environ["MODULE_ID"]
-
-try:
-    # Get the certificate route from the API
-    with urllib.request.urlopen(f'http://127.0.0.1/{api_path}/api/http/routers/certificate-{fqdn}@redis') as res:
-        traefik_https_route = json.load(res)
-
-    # Open the certificates storage file
-    with open(f'/home/{moduleid}/.local/share/containers/storage/volumes/traefik-acme/_data/acme.json') as f:
-        acme_storage = json.load(f)
-
-    certificate['fqdn'] = fqdn
-
-    certificate['obtained'] = False
-
-    resolver = traefik_https_route['tls']['certResolver']
-
-    certificates = acme_storage[resolver].get('Certificates')
-
-    # Check if the certificate is present in the storage
-    for cert in certificates if certificates else []:
-        if cert['domain']['main'] == data['fqdn']:
-            certificate['obtained'] = True
-            break
-
-except urllib.error.HTTPError as e:
-    if e.code == 404:
-        # If the certificate is not found, return an empty JSON object
-        pass
-
-except urllib.error.URLError as e:
-    raise Exception(f'Error reaching traefik daemon: {e.reason}') from e
-
-json.dump(certificate, fp=sys.stdout)
+json.dump(get_certificate(json.load(sys.stdin)), fp=sys.stdout)

--- a/imageroot/actions/get-route/20readconfig
+++ b/imageroot/actions/get-route/20readconfig
@@ -21,65 +21,11 @@
 #
 
 import json
-import os
-import agent
 import sys
-import re
-import urllib.request
+import agent
+from get_route import get_route
 
 # Try to parse the stdin as JSON.
 # If parsing fails, output everything to stderr
-data = json.load(sys.stdin)
-module = data['instance']
-route = {}
 
-api_path = os.environ["API_PATH"]
-try:
-    # Get the http route from the API
-    with urllib.request.urlopen(f'http://127.0.0.1/{api_path}/api/http/routers/{module}-https@redis') as res:
-        traefik_https_route = json.load(res)
-    # Get the https route from the API
-    with urllib.request.urlopen(f'http://127.0.0.1/{api_path}/api/http/routers/{module}-http@redis') as res:
-        traefik_http_route = json.load(res)
-
-    service_name = traefik_https_route['service']
-    # Get the service from the API
-    with urllib.request.urlopen(f'http://127.0.0.1/{api_path}/api/http/services/{service_name}@redis') as res:
-        service = json.load(res)
-
-    route['instance'] = data['instance']
-
-    # Extract the hostname from the rule of the router
-    r =  re.match(r"^.*Host\(`(.*?)`\).*$", traefik_https_route['rule'])
-    if r:
-        route['host'] = r.group(1)
-
-    # Extract the path from the rule of the router
-    r =  re.match(r"^.*Path\(`(.*?)`\).*$", traefik_https_route['rule'])
-    if r:
-        route['path'] = r.group(1)
-
-    # Get the target URL from the service
-    route['url'] = service['loadBalancer']['servers'][0]['url']
-
-    # Check if the certificate is retrieved automatically
-    route['lets_encrypt'] = True if traefik_https_route['tls'].get("certResolver") else False
-
-    middlewares = traefik_http_route.get("middlewares")
-
-    # Check if redirect http to https is enabled
-    route['http2https'] = True if middlewares and "http2https-redirectscheme@redis" in middlewares else False
-
-    # Check if the path is striped from the request
-    if route.get("path"):
-        route['strip_prefix'] = True if middlewares and f'{module}-stripprefix@redis' in middlewares else False
-
-except urllib.error.HTTPError as e:
-    if e.code == 404:
-        # If the route is not found, return an empty JSON object
-        pass
-
-except urllib.error.URLError as e:
-    raise Exception(f'Error reaching traefik daemon: {e.reason}')
-
-json.dump(route, fp=sys.stdout)
+json.dump(get_route(json.load(sys.stdin)), fp=sys.stdout)

--- a/imageroot/actions/set-certificate/20writeconfig
+++ b/imageroot/actions/set-certificate/20writeconfig
@@ -41,7 +41,7 @@ if not agent_id:
     raise Exception("AGENT_ID not found inside the environemnt")
 
 # Connect to redis
-rdb = agent.redis_connect(privileged=True)
+rdb = agent.redis_connect(privileged=True).pipeline()
 
 # Setup HTTP ans HTTPS routers
 router=f'{agent_id}/kv/http/routers/certificate-{data["fqdn"]}'
@@ -53,6 +53,9 @@ rdb.set(f'{router}/priority', '1')
 rdb.set(f'{router}/tls', "true")
 rdb.set(f'{router}/tls/domains/0/main', data["fqdn"])
 rdb.set(f'{router}/tls/certresolver', "letsencrypt")
+
+# Write the configuration on redis
+rdb.execute()
 
 # Output valid JSON
 print("true")

--- a/imageroot/actions/set-certificate/21waitsync
+++ b/imageroot/actions/set-certificate/21waitsync
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import json
+import sys
+import time
+from get_certificate import get_certificate
+
+data = json.load(sys.stdin)
+retry = 0
+
+while get_certificate(data).get('fqdn') != data['fqdn'] and retry <= 10:
+    retry += 1
+    time.sleep(1)

--- a/imageroot/actions/set-route/20writeconfig
+++ b/imageroot/actions/set-route/20writeconfig
@@ -40,7 +40,7 @@ if not agent_id:
     raise Exception("AGENT_ID not found inside the environemnt")
 
 # Connect to redis
-r = agent.redis_connect(privileged=True)
+r = agent.redis_connect(privileged=True).pipeline()
 
 # Prepare common key prefix
 prefix=f'{agent_id}/kv/http'
@@ -104,3 +104,6 @@ if data.get("strip_prefix"):
     r.set(f'{middlewares}/{data["instance"]}-stripprefix/stripPrefix/prefixes/0', f'{path}')
     r.set(f'{router}/middlewares/1', f'{data["instance"]}-stripprefix')
     r.set(f'{router_s}/middlewares/1', f'{data["instance"]}-stripprefix')
+
+# Write the configuration on redis
+r.execute()

--- a/imageroot/actions/set-route/21waitsync
+++ b/imageroot/actions/set-route/21waitsync
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import json
+import sys
+import time
+from get_route import get_route
+
+data = json.load(sys.stdin)
+retry = 0
+
+while get_route(data).get('instance') != data['instance'] and retry <= 10:
+    retry += 1
+    time.sleep(1)

--- a/imageroot/pypkg/get_certificate.py
+++ b/imageroot/pypkg/get_certificate.py
@@ -36,6 +36,10 @@ def get_certificate(data):
         with urllib.request.urlopen(f'http://127.0.0.1/{api_path}/api/http/routers/certificate-{fqdn}@redis') as res:
             traefik_https_route = json.load(res)
 
+        # Check if the route is ready to use
+        if traefik_https_route['status'] == 'disabled':
+            return {}
+
         # Open the certificates storage file
         with open(f'/home/{moduleid}/.local/share/containers/storage/volumes/traefik-acme/_data/acme.json') as f:
             acme_storage = json.load(f)

--- a/imageroot/pypkg/get_certificate.py
+++ b/imageroot/pypkg/get_certificate.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import json
+import os
+import agent
+import urllib.request
+
+def get_certificate(data):
+    try:
+        fqdn = data['fqdn']
+        certificate = {}
+        api_path = os.environ["API_PATH"]
+        moduleid = os.environ["MODULE_ID"]
+
+        # Get the certificate route from the API
+        with urllib.request.urlopen(f'http://127.0.0.1/{api_path}/api/http/routers/certificate-{fqdn}@redis') as res:
+            traefik_https_route = json.load(res)
+
+        # Open the certificates storage file
+        with open(f'/home/{moduleid}/.local/share/containers/storage/volumes/traefik-acme/_data/acme.json') as f:
+            acme_storage = json.load(f)
+
+        certificate['fqdn'] = fqdn
+
+        certificate['obtained'] = False
+
+        resolver = traefik_https_route['tls']['certResolver']
+
+        certificates = acme_storage[resolver].get('Certificates')
+
+        # Check if the certificate is present in the storage
+        for cert in certificates if certificates else []:
+            if cert['domain']['main'] == data['fqdn']:
+                certificate['obtained'] = True
+                break
+
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            # If the certificate is not found, return an empty JSON object
+            pass
+
+    except urllib.error.URLError as e:
+        raise Exception(f'Error reaching traefik daemon: {e.reason}') from e
+
+    return certificate

--- a/imageroot/pypkg/get_certificate.py
+++ b/imageroot/pypkg/get_certificate.py
@@ -40,16 +40,15 @@ def get_certificate(data):
         if traefik_https_route['status'] == 'disabled':
             return {}
 
-        # Open the certificates storage file
-        with open(f'/home/{moduleid}/.local/share/containers/storage/volumes/traefik-acme/_data/acme.json') as f:
-            acme_storage = json.load(f)
-
         certificate['fqdn'] = fqdn
 
         certificate['obtained'] = False
 
-        resolver = traefik_https_route['tls']['certResolver']
+        # Open the certificates storage file
+        with open(f'/home/{moduleid}/.local/share/containers/storage/volumes/traefik-acme/_data/acme.json') as f:
+            acme_storage = json.load(f)
 
+        resolver = traefik_https_route['tls']['certResolver']
         certificates = acme_storage[resolver].get('Certificates')
 
         # Check if the certificate is present in the storage
@@ -65,5 +64,9 @@ def get_certificate(data):
 
     except urllib.error.URLError as e:
         raise Exception(f'Error reaching traefik daemon: {e.reason}') from e
+
+    except json.decoder.JSONDecodeError:
+            # The acme storage is empty or corrupted, return the certificate as requested but not obtained
+            pass
 
     return certificate

--- a/imageroot/pypkg/get_route.py
+++ b/imageroot/pypkg/get_route.py
@@ -43,6 +43,10 @@ def get_route(data):
         with urllib.request.urlopen(f'http://127.0.0.1/{api_path}/api/http/routers/{module}-http@redis') as res:
             traefik_http_route = json.load(res)
 
+        # Check if the route is ready to use
+        if traefik_http_route['status'] == 'disabled' or traefik_https_route['status'] == 'disabled':
+            return {}
+
         service_name = traefik_https_route['service']
         # Get the service from the API
         with urllib.request.urlopen(f'http://127.0.0.1/{api_path}/api/http/services/{service_name}@redis') as res:

--- a/imageroot/pypkg/get_route.py
+++ b/imageroot/pypkg/get_route.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2022 Nethesis S.r.l.
+# http://www.nethesis.it - nethserver@nethesis.it
+#
+# This script is part of NethServer.
+#
+# NethServer is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License,
+# or any later version.
+#
+# NethServer is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with NethServer.  If not, see COPYING.
+#
+
+import json
+import os
+import agent
+import re
+import urllib.request
+
+# Try to parse the stdin as JSON.
+# If parsing fails, output everything to stderr
+
+def get_route(data):
+
+    module = data['instance']
+    route = {}
+    api_path = os.environ["API_PATH"]
+
+    try:
+        # Get the http route from the API
+        with urllib.request.urlopen(f'http://127.0.0.1/{api_path}/api/http/routers/{module}-https@redis') as res:
+            traefik_https_route = json.load(res)
+        # Get the https route from the API
+        with urllib.request.urlopen(f'http://127.0.0.1/{api_path}/api/http/routers/{module}-http@redis') as res:
+            traefik_http_route = json.load(res)
+
+        service_name = traefik_https_route['service']
+        # Get the service from the API
+        with urllib.request.urlopen(f'http://127.0.0.1/{api_path}/api/http/services/{service_name}@redis') as res:
+            service = json.load(res)
+
+        route['instance'] = data['instance']
+
+        # Extract the hostname from the rule of the router
+        r =  re.match(r"^.*Host\(`(.*?)`\).*$", traefik_https_route['rule'])
+        if r:
+            route['host'] = r.group(1)
+
+        # Extract the path from the rule of the router
+        r =  re.match(r"^.*Path\(`(.*?)`\).*$", traefik_https_route['rule'])
+        if r:
+            route['path'] = r.group(1)
+
+        # Get the target URL from the service
+        route['url'] = service['loadBalancer']['servers'][0]['url']
+
+        # Check if the certificate is retrieved automatically
+        route['lets_encrypt'] = True if traefik_https_route['tls'].get("certResolver") else False
+
+        middlewares = traefik_http_route.get("middlewares")
+
+        # Check if redirect http to https is enabled
+        route['http2https'] = True if middlewares and "http2https-redirectscheme@redis" in middlewares else False
+
+        # Check if the path is striped from the request
+        if route.get("path"):
+            route['strip_prefix'] = True if middlewares and f'{module}-stripprefix@redis' in middlewares else False
+
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            # If the route is not found, return an empty JSON object
+            pass
+
+    except urllib.error.URLError as e:
+        raise Exception(f'Error reaching traefik daemon: {e.reason}')
+
+    return route

--- a/tests/10_traefik_routes_api.robot
+++ b/tests/10_traefik_routes_api.robot
@@ -54,6 +54,5 @@ Delete routes
     Run task    module/traefik1/delete-route   	 {"instance": "module3"}
 
 Get Empty routes list
-    Sleep    20s
     ${response} =  Run task    module/traefik1/list-routes    {}
     Should Be Empty    ${response}

--- a/tests/20_traefik_certificates_api.robot
+++ b/tests/20_traefik_certificates_api.robot
@@ -20,6 +20,5 @@ Delete certificate
     Run task    module/traefik1/delete-certificate   	 {"fqdn": "example.com"}
 
 Get empty certificates list
-    Sleep    10s
     ${response} =  Run task    module/traefik1/list-certificates    {}
     Should Be Empty    ${response}


### PR DESCRIPTION
Calling an API on NS8 system, via `agent.run()` or `api-cli` cli, is supposed to beave synchronous and return the control to the called process only at the end of action execution.
With the `traefik`'s APIs the synchronous behavior is not respected because when writing the configuration to Redis it may take some time before that `traefik` read the new configuration and fully apply it. 
This can lead to undefined behavior in that time frame, like a partially configured route that returns `404` or `500` when the caller application expects instead the route to be ready.

This PR tries to correct the above problem with these steps:
* Make the read APIs aware that the system can be partially configured and handle that cases.
* Use the Redis pipelining mechanism to wire the configuration, to minimize the case for incomplete configurations.
* The write API will wait until the configuration is fully loaded by `traefik` before returning the execution to the caller.