### PR TITLE
list-(certificates|routes): add expand_list option

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,9 @@ api-cli run delete-route --agent module/traefik1 --data '{"instance": "module1"}
 
 This action returns a list of configured routes, the list is an JSON array, and if no route is configured, an
 empty array is returned.
-The action takes no parameter:
+
+The action takes 1 optional parameter:
+- `expand_list`: if set to `true` the list will be expanded with all route's details
 
 Example:
 ```
@@ -123,6 +125,42 @@ Output:
 ```json
 ["module1", "module2", "module3"]
 ```
+
+Example list expanded:
+```
+api-cli run list-routes --agent module/traefik1 --data '{"expand_list": true}'
+```
+
+Output:
+```json
+[
+  {
+    "instance": "module1",
+    "host": "module.example.org",
+    "url": "http://127.0.0.0:2000",
+    "lets_encrypt": true,
+    "http2https": true
+  },
+  {
+    "instance": "module2",
+    "host": "module.example.org",
+    "path": "/foo",
+    "url": "http://127.0.0.0:2000",
+    "lets_encrypt": true,
+    "http2https": true,
+    "strip_prefix": false
+  },
+  {
+    "instance": "module3",
+    "path": "/foo",
+    "url": "http://127.0.0.0:2000",
+    "lets_encrypt": false,
+    "http2https": true,
+    "strip_prefix": false
+  }
+]
+```
+
 
 ## set-certificate
 
@@ -177,7 +215,9 @@ api-cli run delete-certificate --agent module/traefik1 --data "{\"fqdn\": \"$(ho
 
 This action returns a list of requested certificate, the list is an JSON array, and if no certificate was requested, an
 empty array is returned.
-The action takes no parameter:
+
+The action takes 1 optional parameter:
+- `expand_list`: if set to `true` the list will be expanded with all certificate's details
 
 Example:
 ```
@@ -188,6 +228,17 @@ Output:
 ```json
 ["example.com"]
 ```
+
+Example list expanded:
+```
+api-cli run list-certificates --agent module/traefik1 --data '{"expand_list": true}'
+```
+
+Output:
+```json
+[{"fqdn": "example.com", "obtained": false}]
+```
+
 ## set-acme-server
 
 This action allows setting an ACME server that traefik will use to request the HTTPS certificates.

--- a/imageroot/actions/list-certificates/20readconfig
+++ b/imageroot/actions/list-certificates/20readconfig
@@ -25,9 +25,12 @@ import os
 import agent
 import sys
 import urllib.request
+from get_certificate import get_certificate
 
 
 api_path = os.environ["API_PATH"]
+
+data = json.load(sys.stdin)
 
 # Get the list of routers keys
 try:
@@ -37,7 +40,10 @@ except urllib.error.URLError as e:
     raise Exception(f'Error reaching traefik daemon: {e.reason}') from e
 
 # Gernerate the list of certificates
-routes = [ route['name'].removeprefix('certificate-').removesuffix('@redis') for route in traefik_routes
+certificates = [ route['name'].removeprefix('certificate-').removesuffix('@redis') for route in traefik_routes
         if route['name'].startswith('certificate-') and route['name'].endswith('@redis') ]
 
-json.dump(routes, fp=sys.stdout)
+if data != None and data.get('expand_list'):
+    certificates = [ get_certificate({'fqdn': certificate}) for certificate in certificates ]
+
+json.dump(certificates, fp=sys.stdout)

--- a/imageroot/actions/list-certificates/validate-input.json
+++ b/imageroot/actions/list-certificates/validate-input.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "list-certificates input",
+    "$id": "http://schema.nethserver.org/traefik/list-certificates-output.json",
+    "description": "Get a list of requested certificates",
+    "examples": [
+        {"expand_list": true}
+    ],
+    "oneOf": [{
+	    "type": "object",
+	    "additionalProperties": false,
+	    "required": ["expand_list"],
+	    "properties": {
+		    "expand_list": {
+			    "type":"boolean",
+			    "title": "Expand the certificate on the list"
+		    }
+	    }
+    },{"type":"null"}]
+}

--- a/imageroot/actions/list-certificates/validate-output.json
+++ b/imageroot/actions/list-certificates/validate-output.json
@@ -9,8 +9,14 @@
     ],
     "type": "array",
     "items": {
-	    "type": "string",
-            "format": "hostname",
-            "title": "A fully qualified domain name"
+	    "oneOf":[{
+		    "type": "object",
+		    "title": "A certificate expanded"
+	    },
+	    {
+		    "type": "string",
+		    "format": "hostname",
+		    "title": "A fully qualified domain name"
+	    }]
     }
 }

--- a/imageroot/actions/list-routes/20readconfig
+++ b/imageroot/actions/list-routes/20readconfig
@@ -25,9 +25,12 @@ import os
 import agent
 import sys
 import urllib.request
+from get_route import get_route
 
 
 api_path = os.environ["API_PATH"]
+
+data = json.load(sys.stdin)
 
 # Get the list of routers keys
 try:
@@ -41,5 +44,8 @@ routes = [ route['name'].removesuffix('-https@redis') for route in traefik_route
 
 # Don't list custom `/cluster-admin` route
 routes = list(filter(lambda route: route != "ApiServer", routes))
+
+if data != None and data.get('expand_list'):
+    routes = [ get_route({'instance': route}) for route in routes ]
 
 json.dump(routes, fp=sys.stdout)

--- a/imageroot/actions/list-routes/validate-input.json
+++ b/imageroot/actions/list-routes/validate-input.json
@@ -1,0 +1,20 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "list-routes input",
+    "$id": "http://schema.nethserver.org/traefik/list-routes-output.json",
+    "description": "Get a list of configured routes",
+    "examples": [
+        {"expand_list": true}
+    ],
+    "oneOf": [{
+	    "type": "object",
+	    "additionalProperties": false,
+	    "required": ["expand_list"],
+	    "properties": {
+		    "expand_list": {
+			    "type":"boolean",
+			    "title": "Expand the route on the list"
+		    }
+	    }
+    },{"type":"null"}]
+}

--- a/imageroot/actions/list-routes/validate-output.json
+++ b/imageroot/actions/list-routes/validate-output.json
@@ -9,7 +9,13 @@
     ],
     "type": "array",
     "items": {
-	    "type": "string",
-            "title": "Name of the route"
+	    "oneOf":[{
+		    "type": "object",
+		    "title": "A route expanded"
+	    },
+	    {
+		    "type": "string",
+		    "title": "Name of the route"
+	    }]
     }
 }

--- a/tests/10_traefik_routes_api.robot
+++ b/tests/10_traefik_routes_api.robot
@@ -43,10 +43,33 @@ Get host & path route
     Should Be Equal As Strings    ${response['strip_prefix']}    False
 
 Get routes list
-    ${response} =  Run task    module/traefik1/list-routes    {}
+    ${response} =  Run task    module/traefik1/list-routes    null
     Should Contain    ${response}    module1
     Should Contain    ${response}    module2
     Should Contain    ${response}    module3
+
+Get expanded routes list
+    ${response} =  Run task    module/traefik1/list-routes    {"expand_list": true}
+    Should Be Equal As Strings    ${response[0]['instance']}        module1
+    Should Be Equal As Strings    ${response[0]['path']}            /foo
+    Should Be Equal As Strings    ${response[0]['url']}              http://127.0.0.0:2000
+    Should Be Equal As Strings    ${response[0]['lets_encrypt']}    False
+    Should Be Equal As Strings    ${response[0]['http2https']}      True
+    Should Be Equal As Strings    ${response[0]['strip_prefix']}    False
+
+    Should Be Equal As Strings    ${response[1]['instance']}        module2
+    Should Be Equal As Strings    ${response[1]['host']}            foo.example.org
+    Should Be Equal As Strings    ${response[1]['url']}             http://127.0.0.0:2000
+    Should Be Equal As Strings    ${response[1]['lets_encrypt']}    True
+    Should Be Equal As Strings    ${response[1]['http2https']}      True
+
+    Should Be Equal As Strings    ${response[2]['instance']}        module3
+    Should Be Equal As Strings    ${response[2]['path']}            /bar
+    Should Be Equal As Strings    ${response[2]['host']}            bar.example.org
+    Should Be Equal As Strings    ${response[2]['url']}              http://127.0.0.0:2000
+    Should Be Equal As Strings    ${response[2]['lets_encrypt']}    True
+    Should Be Equal As Strings    ${response[2]['http2https']}      True
+    Should Be Equal As Strings    ${response[2]['strip_prefix']}    False
 
 Delete routes
     Run task    module/traefik1/delete-route   	 {"instance": "module1"}
@@ -54,5 +77,5 @@ Delete routes
     Run task    module/traefik1/delete-route   	 {"instance": "module3"}
 
 Get Empty routes list
-    ${response} =  Run task    module/traefik1/list-routes    {}
+    ${response} =  Run task    module/traefik1/list-routes    null
     Should Be Empty    ${response}

--- a/tests/20_traefik_certificates_api.robot
+++ b/tests/20_traefik_certificates_api.robot
@@ -27,12 +27,17 @@ Get invalid cerficate status
     Should Be Equal As Strings    ${response['obtained']}    False
 
 Get certificate list
-    ${response} =  Run task    module/traefik1/list-certificates    {}
+    ${response} =  Run task    module/traefik1/list-certificates    null
     Should Contain    ${response}    example.com
+
+Get expanded certificate list
+    ${response} =  Run task    module/traefik1/list-certificates    {"expand_list": true}
+    Should Be Equal As Strings    ${response[0]['fqdn']}        example.com
+    Should Be Equal As Strings    ${response[0]['obtained']}    False
 
 Delete certificate
     Run task    module/traefik1/delete-certificate   	 {"fqdn": "example.com"}
 
 Get empty certificates list
-    ${response} =  Run task    module/traefik1/list-certificates    {}
+    ${response} =  Run task    module/traefik1/list-certificates    null
     Should Be Empty    ${response}


### PR DESCRIPTION
If set to `true` the routes/certificates list will be expanded with all details.
The UI can use this new option to retrieve the full routes/certificates list and display it as a table or check if the path was already used, without run N tasks to get the all properties of the routes.