### PR TITLE
Fix certificate-updated event name

### DIFF
--- a/imageroot/bin/export-certificate
+++ b/imageroot/bin/export-certificate
@@ -26,7 +26,7 @@
 # If a certificate has been created or updated,
 # certificate and private keys are saved inside Redis in key
 # named module/<module_id>/certificate/<domain> and
-# the certificate-update event is signaled.
+# the certificate-updated event is signaled.
 #
 
 import os
@@ -57,8 +57,8 @@ for info in certificates:
         print(f'Saving certificate and key to {rkey}')
         rdb.hset(rkey, mapping={"cert": info["certificate"], "key":  info["key"]})
 
-        # signal the certificate-update event
-        event_key = f'module/{module_id}/event/certificate-update'
+        # signal the certificate-updated event
+        event_key = f'module/{module_id}/event/certificate-updated'
         print(f'Publishing event {event_key}')
         event = {"certificate": info["certificate"], "key": info["key"], "node": node_id, "module": module_id, "domain": info["domain"]}
         rdb.publish(event_key, json.dumps(event))


### PR DESCRIPTION
According to docs, the rule is "use past tense inside the name".