### PR TITLE
New API role "certadm"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,22 @@
 
 This module implements a proxy for web applications using [Traefik](https://doc.traefik.io/traefik/).
 
-The module exposes 2 actions:
-- `set-route`
-- `get-route`
-- `delete-route`
-- `list-routes`
-- `set-certificate`
-- `get-certificate`
-- `delete-certificate`
-- `list-certificates`
-- `set-acme-server`
-- `get-acme-server`
+The following table summarizes the available actions and the role(s)
+required to invoke them. For simplicity, the builtin `owner` and `reader`
+roles are omitted.
+
+| Action      | Roles    |
+|-------------|----------|
+| `set-route` | routeadm |
+| `get-route` | routeadm |
+| `delete-route` | routeadm |
+| `list-routes` | routeadm |
+| `set-certificate` | certadm |
+| `get-certificate` | certadm |
+| `delete-certificate` | certadm |
+| `list-certificates` | certadm |
+| `set-acme-server` | |
+| `get-acme-server` | |
 
 ## set-route
 

--- a/imageroot/actions/create-module/30grants
+++ b/imageroot/actions/create-module/30grants
@@ -26,5 +26,9 @@ exec 1>&2 # ensure any output is sent to stderr
 #
 # Allow other modules to call our *-route actions by requiring the "routeadm" role
 #
+redis-exec SADD "${AGENT_ID}/roles/routeadm" "delete-route" "set-route" "get-route" "list-routes"
 
-redis-exec SADD "${AGENT_ID}/roles/routeadm" "delete-route" "set-route"
+#
+# Allow other modules to call our *-certificate actions by requiring the "certadm" role
+#
+redis-exec SADD "${AGENT_ID}/roles/certadm" "delete-certificate" "set-certificate" "get-certificate" "list-certificates"


### PR DESCRIPTION
In this PR

- Define the new role
- Fix routeadm
- Update README

The `certadm` role is necessary to modules like ns8-mail that provide non-HTTP based services: the `set-route` API does not fit them.

