### PR TITLE
(get|set)-route: add user_created flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ This is the priority of the rules type evaluation (top-down):
 - `lets_encrypt`: can be `true` or `false`, if set to `true` request a valid Let's Encrypt certificate, mandatory
 - `http2https` can be `true` or `false`, if set to `true` HTTP will be redirect to HTTPS, mandatory
 - `strip_prefix`: can be `true` or `false`, if set to `true` the prefix of the requested path will be stripped from the original request before sending it to the downstream server.
+- `user_created`: can be `true` or `false`, if set to `true` the route will be marked as manually created.
 
 ### Examples
 

--- a/imageroot/actions/get-route/validate-output.json
+++ b/imageroot/actions/get-route/validate-output.json
@@ -105,6 +105,12 @@
 	    "type": "boolean",
 	    "title": "Strip prefix path",
 	    "description": "Strip the path prefix from the request"
+	},
+	"user_created": {
+	    "type": "boolean",
+	    "title": "User created route flag",
+	    "description": "If true, the route is flagged as manually created by a user"
 	}
+
     }
 }

--- a/imageroot/actions/set-route/20writeconfig
+++ b/imageroot/actions/set-route/20writeconfig
@@ -117,5 +117,11 @@ else:
     r.delete(f'{router}/middlewares/1')
     r.delete(f'{router_s}/middlewares/1')
 
+# Mark route as user_created
+if data.get('user_created') is not None and data["user_created"] is True:
+    r.sadd(f'{agent_id}/user_created_routes', data["instance"])
+else:
+    r.srem(f'{agent_id}/user_created_routes', data["instance"])
+
 # Write the configuration on redis
 r.execute()

--- a/imageroot/actions/set-route/validate-input.json
+++ b/imageroot/actions/set-route/validate-input.json
@@ -90,6 +90,12 @@
 	    "type": "boolean",
 	    "title": "Strip prefix path",
 	    "description": "Strip the path prefix from the request"
+	},
+	"user_created": {
+	    "type": "boolean",
+	    "title": "User created route flag",
+	    "description": "If true, the route is flagged as manually created by a user"
 	}
+
     }
 }

--- a/imageroot/pypkg/get_route.py
+++ b/imageroot/pypkg/get_route.py
@@ -35,6 +35,7 @@ def get_route(data):
     route = {}
     api_path = os.environ["API_PATH"]
 
+    agent_id = os.environ["AGENT_ID"]
     try:
         # Get the http route from the API
         with urllib.request.urlopen(f'http://127.0.0.1/{api_path}/api/http/routers/{module}-https@redis') as res:
@@ -78,6 +79,10 @@ def get_route(data):
         # Check if the path is striped from the request
         if route.get("path"):
             route['strip_prefix'] = True if middlewares and f'{module}-stripprefix@redis' in middlewares else False
+
+        # Check if the route was created manually
+        rdb = agent.redis_connect(privileged=True)
+        route['user_created'] = rdb.sismember(f'{agent_id}/user_created_routes', data["instance"])
 
     except urllib.error.HTTPError as e:
         if e.code == 404:

--- a/tests/10_traefik_routes_api.robot
+++ b/tests/10_traefik_routes_api.robot
@@ -13,7 +13,7 @@ Create a host rule
 
 Create a host & path rule
     ${response} =  Run task    module/traefik1/set-route
-    ...    {"instance": "module3", "url": "http://127.0.0.0:2000", "host": "bar.example.org", "path": "/bar", "lets_encrypt": true, "http2https": true}
+    ...    {"instance": "module3", "url": "http://127.0.0.0:2000", "host": "bar.example.org", "path": "/bar", "lets_encrypt": true, "http2https": true, "user_created": true}
 
 Create an invalid path route
     Run Keyword And Expect Error    *    Run task    module/traefik1/set-route
@@ -27,6 +27,7 @@ Get path route
     Should Be Equal As Strings    ${response['lets_encrypt']}    False
     Should Be Equal As Strings    ${response['http2https']}      True
     Should Be Equal As Strings    ${response['strip_prefix']}    False
+    Should Be Equal As Strings    ${response['user_created']}    False
 
 Get host route
     ${response} =  Run task    module/traefik1/get-route    {"instance": "module2"}
@@ -35,6 +36,7 @@ Get host route
     Should Be Equal As Strings    ${response['url']}             http://127.0.0.0:2000
     Should Be Equal As Strings    ${response['lets_encrypt']}    True
     Should Be Equal As Strings    ${response['http2https']}      True
+    Should Be Equal As Strings    ${response['user_created']}    False
 
 Get host & path route
     ${response} =  Run task    module/traefik1/get-route    {"instance": "module3"}
@@ -45,6 +47,7 @@ Get host & path route
     Should Be Equal As Strings    ${response['lets_encrypt']}    True
     Should Be Equal As Strings    ${response['http2https']}      True
     Should Be Equal As Strings    ${response['strip_prefix']}    False
+    Should Be Equal As Strings    ${response['user_created']}    True
 
 Get routes list
     ${response} =  Run task    module/traefik1/list-routes    null
@@ -60,12 +63,14 @@ Get expanded routes list
     Should Be Equal As Strings    ${response[0]['lets_encrypt']}    False
     Should Be Equal As Strings    ${response[0]['http2https']}      True
     Should Be Equal As Strings    ${response[0]['strip_prefix']}    False
+    Should Be Equal As Strings    ${response[0]['user_created']}    False
 
     Should Be Equal As Strings    ${response[1]['instance']}        module2
     Should Be Equal As Strings    ${response[1]['host']}            foo.example.org
     Should Be Equal As Strings    ${response[1]['url']}             http://127.0.0.0:2000
     Should Be Equal As Strings    ${response[1]['lets_encrypt']}    True
     Should Be Equal As Strings    ${response[1]['http2https']}      True
+    Should Be Equal As Strings    ${response[1]['user_created']}    False
 
     Should Be Equal As Strings    ${response[2]['instance']}        module3
     Should Be Equal As Strings    ${response[2]['path']}            /bar
@@ -74,6 +79,7 @@ Get expanded routes list
     Should Be Equal As Strings    ${response[2]['lets_encrypt']}    True
     Should Be Equal As Strings    ${response[2]['http2https']}      True
     Should Be Equal As Strings    ${response[2]['strip_prefix']}    False
+    Should Be Equal As Strings    ${response[2]['user_created']}    True
 
 Delete routes
     Run task    module/traefik1/delete-route   	 {"instance": "module1"}


### PR DESCRIPTION
Using `user_created` flag is possible to mark a route as manually created by a user, in this way the UI can avoid a system route begin deleted or modified by mistake.
