### PR TITLE
set-route: change routes priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ of rules:
 
 This is the priority of the rules type evaluation (top-down):
 
-1. only `host`
 1. `host` and `path`
+1. only `host`
 1. only `path`
 
 ### Parameters

--- a/imageroot/actions/set-route/20writeconfig
+++ b/imageroot/actions/set-route/20writeconfig
@@ -62,20 +62,20 @@ if data.get("path") is not None:
     else:
         path_prefix = path = "/"
 
-if data.get("host") is not None and data.get("path") is None:
-    #http routes
-    r.set(f'{router}/rule', f'Host(`{data["host"]}`)')
-    r.set(f'{router}/priority', '3')
-    #https routes
-    r.set(f'{router_s}/rule', f'Host(`{data["host"]}`)')
-    r.set(f'{router_s}/priority', '3')
-elif data.get("host") is not None and data.get("path") is not None:
+if data.get("host") is not None and data.get("path") is not None:
     #http routes
     r.set(f'{router_s}/rule', f'Host(`{data["host"]}`) && (Path(`{path}`) || PathPrefix(`{path_prefix}`))')
-    r.set(f'{router_s}/priority', '2')
+    r.set(f'{router_s}/priority', '3')
     #https routes
     r.set(f'{router}/rule', f'Host(`{data["host"]}`) && (Path(`{path}`) || PathPrefix(`{path_prefix}`))')
+    r.set(f'{router}/priority', '3')
+elif data.get("host") is not None:
+    #http routes
+    r.set(f'{router}/rule', f'Host(`{data["host"]}`)')
     r.set(f'{router}/priority', '2')
+    #https routes
+    r.set(f'{router_s}/rule', f'Host(`{data["host"]}`)')
+    r.set(f'{router_s}/priority', '2')
 else:
     #http routes
     r.set(f'{router}/rule', f'Path(`{path}`) || PathPrefix(`{path_prefix}`)')


### PR DESCRIPTION
Invert the priority of the `host` and the `host` + `path` routes, in
this way the more specific route will win over the more generic one.
