### PR TITLE
expandconfig: remove default LE_MAIL

### DIFF
--- a/imageroot/actions/create-module/10expandconfig
+++ b/imageroot/actions/create-module/10expandconfig
@@ -25,7 +25,6 @@ set -e
 # Redirect any output to the journal (stderr)
 exec 1>&2
 
-LE_EMAIL=${LE_EMAIL:-root@$(hostname -f)}
 LOG_LEVEL=${LOG_LEVEL:-INFO}
 ACME_SERVER_URL=${ACME_SERVER_URL:-https://acme-v02.api.letsencrypt.org/directory}
 


### PR DESCRIPTION
The mail parameter is not mandatory, but if it contains an invalid domain, the certificate challenge will fail with an error like:
```
 Error creating new account :: contact email "root@localhost.localdomain" has invalid domain :
 Domain name does not end with a valid public suffix (TLD)"
```

See https://trello.com/c/R5XZnhDv/332-core-p3-handle-bad-fqdns