### PR TITLE
Remove obsolete bash set-env

### DIFF
--- a/imageroot/actions/create-module/05set_env
+++ b/imageroot/actions/create-module/05set_env
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import agent
+import os
+
+log_level = os.environ.get('LOG_LEVEL', 'INFO')
+acme_server_url = os.environ.get('ACME_SERVER_URL', 'https://acme-v02.api.letsencrypt.org/directory')
+le_email = os.environ.get('LE_EMAIL',"")
+uuid =  os.popen("uuidgen")
+
+agent.set_env('LOG_LEVEL', log_level)
+agent.set_env('ACME_SERVER_URL', acme_server_url)
+agent.set_env('LE_EMAIL', le_email)
+agent.set_env('API_PATH', uuid.read())

--- a/imageroot/actions/create-module/10expandconfig
+++ b/imageroot/actions/create-module/10expandconfig
@@ -25,16 +25,6 @@ set -e
 # Redirect any output to the journal (stderr)
 exec 1>&2
 
-LOG_LEVEL=${LOG_LEVEL:-INFO}
-ACME_SERVER_URL=${ACME_SERVER_URL:-https://acme-v02.api.letsencrypt.org/directory}
-
-cat >&${AGENT_COMFD} <<EOF
-set-env LE_EMAIL ${LE_EMAIL}
-set-env LOG_LEVEL ${LOG_LEVEL}
-set-env ACME_SERVER_URL ${ACME_SERVER_URL}
-dump-env
-EOF
-
 cat >traefik.yaml <<EOF 
 defaultEntryPoints:
   - http

--- a/imageroot/actions/create-module/50create
+++ b/imageroot/actions/create-module/50create
@@ -68,12 +68,6 @@ EOF
 #
 # Setup APIs endpoint
 #
-API_PATH=$(uuidgen)
-cat >&${AGENT_COMFD} <<EOF
-set-env API_PATH ${API_PATH}
-dump-env
-EOF
-
 redis-exec <<EOF
 SET "${AGENT_ID}/kv/http/routers/ApisEndpointHttp/entryPoints/0" "http"
 SET "${AGENT_ID}/kv/http/routers/ApisEndpointHttp/rule" "PathPrefix(\`/${API_PATH}/api\`)"


### PR DESCRIPTION
following https://trello.com/c/jBkc6Qwt/365-core-p1-agent-set-env-deprecation

Remove the deprecated set-env
Sync the agent Redis */environment key on every action run, no matter for the exit code