### PR TITLE
Custom certificate management

### DIFF
--- a/imageroot/actions/delete-certificate/20writeconfig
+++ b/imageroot/actions/delete-certificate/20writeconfig
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (C) 2021 Nethesis S.r.l.
+# Copyright (C) 2023 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
 #
 # This script is part of NethServer.
@@ -32,6 +32,8 @@ import sys
 import os
 import agent
 
+from custom_certificate_manager import delete_custom_certificate
+
 # Try to parse the stdin as JSON.
 # If parsing fails, output everything to stderr
 data = json.load(sys.stdin)
@@ -40,23 +42,26 @@ agent_id = os.getenv("AGENT_ID", "")
 if not agent_id:
     raise Exception("AGENT_ID not found inside the environemnt")
 
-# Connect to redis
-rdb = agent.redis_connect(privileged=True).pipeline()
+try:
+    delete_custom_certificate(data['fqdn'])
+except FileNotFoundError:
+    # Connect to redis
+    rdb = agent.redis_connect(privileged=True).pipeline()
 
-# Prepare common key prefix
-router=f'{agent_id}/kv/http/routers/certificate-{data["fqdn"]}'
+    # Prepare common key prefix
+    router=f'{agent_id}/kv/http/routers/certificate-{data["fqdn"]}'
 
-# Remove HTTPS router
-rdb.delete(f'{router}/entrypoints')
-rdb.delete(f'{router}/rule')
-rdb.delete(f'{router}/priority')
-rdb.delete(f'{router}/service')
-rdb.delete(f'{router}/tls')
-rdb.delete(f'{router}/tls/domains/0/main')
-rdb.delete(f'{router}/tls/certresolver')
+    # Remove HTTPS router
+    rdb.delete(f'{router}/entrypoints')
+    rdb.delete(f'{router}/rule')
+    rdb.delete(f'{router}/priority')
+    rdb.delete(f'{router}/service')
+    rdb.delete(f'{router}/tls')
+    rdb.delete(f'{router}/tls/domains/0/main')
+    rdb.delete(f'{router}/tls/certresolver')
 
-# Write the configuration on redis
-rdb.execute()
+    # Write the configuration on redis
+    rdb.execute()
 
 # Output valid JSON
 print("true")

--- a/imageroot/actions/get-certificate/20readconfig
+++ b/imageroot/actions/get-certificate/20readconfig
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (C) 2022 Nethesis S.r.l.
+# Copyright (C) 2023 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
 #
 # This script is part of NethServer.
@@ -22,9 +22,17 @@
 
 import json
 import sys
+
+from custom_certificate_manager import info_custom_certificate
 from get_certificate import get_certificate
 
 # Try to parse the stdin as JSON.
 # If parsing fails, output everything to stderr
 
-json.dump(get_certificate(json.load(sys.stdin)), fp=sys.stdout)
+data = json.load(sys.stdin)
+try:
+    cert_info = info_custom_certificate(data['fqdn'])
+except FileNotFoundError:
+    cert_info = get_certificate(data)
+
+json.dump(cert_info, fp=sys.stdout)

--- a/imageroot/actions/list-certificates/20readconfig
+++ b/imageroot/actions/list-certificates/20readconfig
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (C) 2022 Nethesis S.r.l.
+# Copyright (C) 2023 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
 #
 # This script is part of NethServer.
@@ -25,6 +25,8 @@ import os
 import agent
 import sys
 import urllib.request
+
+from custom_certificate_manager import list_custom_certificates
 from get_certificate import get_certificate
 
 
@@ -45,5 +47,7 @@ certificates = [ route['name'].removeprefix('certificate-').removesuffix('@redis
 
 if data != None and data.get('expand_list'):
     certificates = [ get_certificate({'fqdn': certificate}) for certificate in certificates ]
+
+certificates = certificates + list_custom_certificates()
 
 json.dump(certificates, fp=sys.stdout)

--- a/imageroot/pypkg/custom_certificate_manager.py
+++ b/imageroot/pypkg/custom_certificate_manager.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from pathlib import Path
+
+CUSTOM_CERTIFICATES_DIR = 'custom_certificates'
+CUSTOM_TRAEFIK_CONFIG_DIR = 'configs'
+CRT_SUFFIX = '.crt'
+KEY_SUFFIX = '.key'
+
+
+def info_custom_certificate(fqdn):
+    """Get info for custom certificate
+
+    :param fqdn: The FQDN to find in the certificates
+    :type fqdn: str
+    :return: dictionary containing custom certificate info
+    :rtype: dict
+    :raises FileNotFoundError: if no certificate is found for the given FQDN
+    """
+    custom_cert_path = Path(CUSTOM_CERTIFICATES_DIR)
+    for item in custom_cert_path.iterdir():
+        if item.is_file() and item.name == fqdn + CRT_SUFFIX:
+            return {
+                'fqdn': fqdn,
+                'type': 'custom',
+                'obtained': True
+            }
+
+    raise FileNotFoundError(f'Can\'t find custom certificate for {fqdn}.')
+
+
+def list_custom_certificates():
+    """Returns a list of custom certificates uploaded
+
+    :return: list containing data for each custom_certificate found, see info_custom_certificate for more info
+    :rtype: list
+    """
+    custom_certificates = []
+    custom_cert_path = Path(CUSTOM_CERTIFICATES_DIR)
+    for item in custom_cert_path.iterdir():
+        if item.is_file() and item.suffix == CRT_SUFFIX:
+            custom_certificates.append(info_custom_certificate(item.name.removesuffix(CRT_SUFFIX)))
+
+    return custom_certificates
+
+
+def delete_custom_certificate(fqdn):
+    """Delete custom certificate from system and Traefik configuration
+
+    :param fqdn: FQDN to delete from filesystem
+    :type fqdn: str
+    :raises FileNotFoundError: if certificate or key is missing
+    """
+    cert_file_path = Path(CUSTOM_CERTIFICATES_DIR + f'/{fqdn}{CRT_SUFFIX}')
+    key_file_path = Path(CUSTOM_CERTIFICATES_DIR + f'/{fqdn}{KEY_SUFFIX}')
+    cert_config_path = Path(CUSTOM_TRAEFIK_CONFIG_DIR + f'/certificate_{fqdn}.yml')
+    # check the presence of both file before removing, ensures that both are deleted, avoiding system inconsistencies
+    if cert_file_path.is_file() and key_file_path.is_file() and cert_config_path.is_file():
+        cert_file_path.unlink()
+        key_file_path.unlink()
+        cert_config_path.unlink()
+    else:
+        raise FileNotFoundError(f'Invalid custom certificate state for {fqdn}.')

--- a/imageroot/pypkg/get_certificate.py
+++ b/imageroot/pypkg/get_certificate.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (C) 2022 Nethesis S.r.l.
+# Copyright (C) 2023 Nethesis S.r.l.
 # http://www.nethesis.it - nethserver@nethesis.it
 #
 # This script is part of NethServer.
@@ -41,6 +41,7 @@ def get_certificate(data):
             return {}
 
         certificate['fqdn'] = fqdn
+        certificate['type'] = 'internal'
 
         certificate['obtained'] = False
 


### PR DESCRIPTION
Adding custom certificate management inside traeifk module

- added library to handle custom certificate management
- added management of custom certificates for `list-certificates`, `get-certificate` and `delete-certificate`

The actions were modified to allow few to no changes to UI, keeping the behaviour the same.  

UI PR: NethServer/ns8-core#413