### PR TITLE
Fixing upgrade from 0.0.12

### DIFF
--- a/imageroot/update-module.d/11dir_structure
+++ b/imageroot/update-module.d/11dir_structure
@@ -1,0 +1,11 @@
+#!/usr/bin/env sh
+
+#
+# Copyright (C) 2023 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+set -e
+
+# Update from 0.0.12
+mkdir -vp custom_certificates configs


### PR DESCRIPTION
Added migration script that ensures that `custom_certificates` and `configs` folder are present.

Tested:
- [x] Fresh install
- [X] Upgrade from 0.0.12 