### PR TITLE
Remove agent.dump_env() deprecated calls

### DIFF
--- a/imageroot/actions/restore-module/06copyenv
+++ b/imageroot/actions/restore-module/06copyenv
@@ -34,5 +34,3 @@ for evar in [
         "ACME_SERVER_URL",
     ]:
     agent.set_env(evar, original_environment[evar])
-
-agent.dump_env()

--- a/imageroot/actions/set-acme-server/20writeconfig
+++ b/imageroot/actions/set-acme-server/20writeconfig
@@ -28,5 +28,3 @@ import os
 data = json.load(sys.stdin)
 
 agent.set_env("ACME_SERVER_URL", data["url"])
-
-agent.dump_env()


### PR DESCRIPTION
Complete https://github.com/NethServer/ns8-traefik/pull/32

References https://trello.com/c/jBkc6Qwt/365-core-p1-agent-set-env-deprecation