### PR TITLE
redis2yaml: handle forwardauth middleware

### DIFF
--- a/imageroot/bin/redis2yml
+++ b/imageroot/bin/redis2yml
@@ -44,7 +44,10 @@ for kv in rdb.scan_iter(f'{prefix}http/*'):
                 middlewares[tmp[1]][tmp[2]][tmp[3]] = list()
             middlewares[tmp[1]][tmp[2]][tmp[3]].append(value)
         else:
-            middlewares[tmp[1]][tmp[2]][tmp[3]] = value
+            if len(tmp) > 4 and tmp[4] == "insecureSkipVerify":
+                middlewares[tmp[1]][tmp[2]][tmp[3]][tmp[4]] = (value == 'True')
+            else:
+                middlewares[tmp[1]][tmp[2]][tmp[3]] = value
     elif tmp[0] == "services":
         if tmp[1] not in services:
             services[tmp[1]] = { "loadBalancer": { "servers": list() } }


### PR DESCRIPTION
Before the fix, the `insecureSkipVerify` parameter was ignored. Raised error:
 Error while building configuration (for the first time): /etc/traefik/configs/mail1-rspamd.yml: tls cannot be a standalone element