### PR TITLE
Fix del permissions in redis2yml

### DIFF
--- a/imageroot/bin/redis2yml
+++ b/imageroot/bin/redis2yml
@@ -24,7 +24,7 @@ services = {}
 routers = {}
 
 prefix = f'module/{instance}/kv/'
-rdb = agent.redis_connect(host='127.0.0.1', privileged = True)
+rdb = agent.redis_connect(privileged = True)
 
 # HTTP
 for kv in rdb.scan_iter(f'{prefix}http/*'):


### PR DESCRIPTION
In a worker node, host 127.0.0.1 is a read-only replica and the `DEL` Redis command fails.