### PR TITLE
Add serversTransports for self-signed certificate verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ This is the priority of the rules type evaluation (top-down):
 ### Parameters
 
 - `instance`: the instance name, which is unique inside the cluster, mandatory
+- `skipCertVerify`: do not verify self signed certificate (boolean)
 - `url`: the backend target URL, mandatory
 - `host`: a fully qualified domain name as virtual host
 - `path`: a path prefix, the matching evaluation will be performed whit and without the trailing slash, eg `/foo` will match `/foo` and `/foo/*`, also `/foo/` will match `/foo` and `/foo/*`
@@ -76,7 +77,8 @@ api-cli run set-route --agent module/traefik1 --data - <<EOF
   "url": "http://127.0.0.1:2000",
   "host": "module.example.org",
   "lets_encrypt": true,
-  "http2https": true
+  "http2https": true,
+  "skipCertVerify": false
 }
 EOF
 ```
@@ -90,7 +92,8 @@ api-cli run set-route --agent module/traefik1 --data - <<EOF
   "host": "module.example.org",
   "path": "/foo",
   "lets_encrypt": true,
-  "http2https": true
+  "http2https": true,
+  "skipCertVerify": false
 }
 EOF
 ```
@@ -103,7 +106,8 @@ api-cli run set-route --agent module/traefik1 --data - <<EOF
   "url": "http://127.0.0.1:2000",
   "path": "/foo",
   "lets_encrypt": true,
-  "http2https": true
+  "http2https": true,
+  "skipCertVerify": false
 }
 EOF
 ```
@@ -117,6 +121,7 @@ api-cli run set-route --agent module/traefik1 --data - <<EOF
   "host": "127.0.0.1",
   "lets_encrypt": false,
   "http2https": false,
+  "skipCertVerify": false,
   "forward_auth": {
       "address": "http://127.0.0.1:9311/api/module/module1/http-basic/add-module1",
       "skip_tls_verify": true
@@ -183,7 +188,8 @@ Output:
     "host": "module.example.org",
     "url": "http://127.0.0.1:2000",
     "lets_encrypt": true,
-    "http2https": true
+    "http2https": true,
+    "skipCertVerify": false
   },
   {
     "instance": "module2",
@@ -192,7 +198,9 @@ Output:
     "url": "http://127.0.0.1:2000",
     "lets_encrypt": true,
     "http2https": true,
-    "strip_prefix": false
+    "strip_prefix": false,
+    "skipCertVerify": true
+
   },
   {
     "instance": "module3",
@@ -200,7 +208,9 @@ Output:
     "url": "http://127.0.0.1:2000",
     "lets_encrypt": false,
     "http2https": true,
-    "strip_prefix": false
+    "strip_prefix": false,
+    "skipCertVerify": false
+
   }
 ]
 ```

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This is the priority of the rules type evaluation (top-down):
 ### Parameters
 
 - `instance`: the instance name, which is unique inside the cluster, mandatory
-- `skipCertVerify`: do not verify self signed certificate (boolean)
+- `skip_cert_verify`: do not verify self signed certificate (boolean)
 - `url`: the backend target URL, mandatory
 - `host`: a fully qualified domain name as virtual host
 - `path`: a path prefix, the matching evaluation will be performed whit and without the trailing slash, eg `/foo` will match `/foo` and `/foo/*`, also `/foo/` will match `/foo` and `/foo/*`
@@ -78,7 +78,7 @@ api-cli run set-route --agent module/traefik1 --data - <<EOF
   "host": "module.example.org",
   "lets_encrypt": true,
   "http2https": true,
-  "skipCertVerify": false
+  "skip_cert_verify": false
 }
 EOF
 ```
@@ -93,7 +93,7 @@ api-cli run set-route --agent module/traefik1 --data - <<EOF
   "path": "/foo",
   "lets_encrypt": true,
   "http2https": true,
-  "skipCertVerify": false
+  "skip_cert_verify": false
 }
 EOF
 ```
@@ -107,7 +107,7 @@ api-cli run set-route --agent module/traefik1 --data - <<EOF
   "path": "/foo",
   "lets_encrypt": true,
   "http2https": true,
-  "skipCertVerify": false
+  "skip_cert_verify": false
 }
 EOF
 ```
@@ -121,7 +121,7 @@ api-cli run set-route --agent module/traefik1 --data - <<EOF
   "host": "127.0.0.1",
   "lets_encrypt": false,
   "http2https": false,
-  "skipCertVerify": false,
+  "skip_cert_verify": false,
   "forward_auth": {
       "address": "http://127.0.0.1:9311/api/module/module1/http-basic/add-module1",
       "skip_tls_verify": true
@@ -189,7 +189,7 @@ Output:
     "url": "http://127.0.0.1:2000",
     "lets_encrypt": true,
     "http2https": true,
-    "skipCertVerify": false
+    "skip_cert_verify": false
   },
   {
     "instance": "module2",
@@ -199,7 +199,7 @@ Output:
     "lets_encrypt": true,
     "http2https": true,
     "strip_prefix": false,
-    "skipCertVerify": true
+    "skip_cert_verify": true
 
   },
   {
@@ -209,7 +209,7 @@ Output:
     "lets_encrypt": false,
     "http2https": true,
     "strip_prefix": false,
-    "skipCertVerify": false
+    "skip_cert_verify": false
 
   }
 ]

--- a/imageroot/actions/get-route/validate-output.json
+++ b/imageroot/actions/get-route/validate-output.json
@@ -10,7 +10,7 @@
             "host": "module.example.org",
             "lets_encrypt": true,
             "http2https": true,
-            "skipCertVerify": true
+            "skip_cert_verify": true
         },
         {
             "instance": "module2",
@@ -20,7 +20,7 @@
             "lets_encrypt": true,
             "http2https": true,
             "strip_prefix": false,
-            "skipCertVerify": true
+            "skip_cert_verify": true
         },
         {
             "instance": "module3",
@@ -29,7 +29,7 @@
             "lets_encrypt": true,
             "http2https": true,
             "strip_prefix": false,
-            "skipCertVerify": true
+            "skip_cert_verify": true
         }
     ],
     "type": "object",
@@ -126,7 +126,7 @@
             "title": "Strip prefix path",
             "description": "Strip the path prefix from the request"
         },
-        "skipCertVerify": {
+        "skip_cert_verify": {
             "type": "boolean",
             "title": "Skip certificate verification",
             "description": "Do not verify the backend's certificate"

--- a/imageroot/actions/get-route/validate-output.json
+++ b/imageroot/actions/get-route/validate-output.json
@@ -9,7 +9,8 @@
             "url": "http://127.0.0.0:2000",
             "host": "module.example.org",
             "lets_encrypt": true,
-            "http2https": true
+            "http2https": true,
+            "skipCertVerify": true
         },
         {
             "instance": "module2",
@@ -18,7 +19,8 @@
             "path": "/foo",
             "lets_encrypt": true,
             "http2https": true,
-            "strip_prefix": false
+            "strip_prefix": false,
+            "skipCertVerify": true
         },
         {
             "instance": "module3",
@@ -26,7 +28,8 @@
             "path": "/foo",
             "lets_encrypt": true,
             "http2https": true,
-            "strip_prefix": false
+            "strip_prefix": false,
+            "skipCertVerify": true
         }
     ],
     "type": "object",
@@ -48,7 +51,8 @@
             "required": [
                 "instance",
                 "url",
-                "http2https"
+                "http2https",
+                "skipCertVerify"
             ]
         },
         {
@@ -122,6 +126,11 @@
             "type": "boolean",
             "title": "Strip prefix path",
             "description": "Strip the path prefix from the request"
+        },
+        "skipCertVerify": {
+            "type": "boolean",
+            "title": "Skip certificate verification",
+            "description": "Do not verify the backend's certificate"
         },
         "user_created": {
             "type": "boolean",

--- a/imageroot/actions/get-route/validate-output.json
+++ b/imageroot/actions/get-route/validate-output.json
@@ -51,8 +51,7 @@
             "required": [
                 "instance",
                 "url",
-                "http2https",
-                "skipCertVerify"
+                "http2https"
             ]
         },
         {

--- a/imageroot/actions/list-routes/validate-output.json
+++ b/imageroot/actions/list-routes/validate-output.json
@@ -7,7 +7,7 @@
         [
             {
                 "instance": "module1",
-                "skipCertVerify": false,
+                "skip_cert_verify": false,
                 "host": "host.domain.com",
                 "path": "/Path",
                 "url": "http://192.168.1.100",
@@ -85,7 +85,7 @@
                         "title": "Strip prefix path",
                         "description": "Strip the path prefix from the request"
                     },
-                    "skipCertVerify": {
+                    "skip_cert_verify": {
                         "type": "boolean",
                         "title": "Skip certificate verification",
                         "description": "Do not verify the backend's certificate"

--- a/imageroot/actions/list-routes/validate-output.json
+++ b/imageroot/actions/list-routes/validate-output.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "$id": "http://schema.nethserver.org/samba/list-routes-output.json",
     "title": "list-routes output",
+    "$id": "http://schema.nethserver.org/samba/list-routes-output.json",
     "description": "Return a list of configured routes",
     "examples": [
         [
@@ -18,7 +18,8 @@
         ],
         [
             "module1"
-        ]
+        ],
+        []
     ],
     "type": "array",
     "items": {

--- a/imageroot/actions/list-routes/validate-output.json
+++ b/imageroot/actions/list-routes/validate-output.json
@@ -158,7 +158,6 @@
                 },
                 "required": [
                     "instance",
-                    "skipCertVerify",
                     "url",
                     "http2https",
                     "user_created"

--- a/imageroot/actions/list-routes/validate-output.json
+++ b/imageroot/actions/list-routes/validate-output.json
@@ -1,21 +1,197 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
-    "title": "list-routes output",
     "$id": "http://schema.nethserver.org/samba/list-routes-output.json",
+    "title": "list-routes output",
     "description": "Return a list of configured routes",
     "examples": [
-	    ["module1"],
-	    []
+        [
+            {
+                "instance": "module1",
+                "skipCertVerify": false,
+                "host": "host.domain.com",
+                "path": "/Path",
+                "url": "http://192.168.1.100",
+                "lets_encrypt": false,
+                "http2https": true,
+                "user_created": true
+            }
+        ],
+        [
+            "module1"
+        ]
     ],
     "type": "array",
     "items": {
-	    "oneOf":[{
-		    "type": "object",
-		    "title": "A route expanded"
-	    },
-	    {
-		    "type": "string",
-		    "title": "Name of the route"
-	    }]
+        "oneOf": [
+            {
+                "type": "object",
+                "title": "A route expanded",
+                "properties": {
+                    "host": {
+                        "required": [
+                            "lets_encrypt"
+                        ]
+                    },
+                    "strip_prefix": {
+                        "required": [
+                            "path"
+                        ]
+                    }
+                },
+                "properties": {
+                    "instance": {
+                        "type": "string",
+                        "title": "Instance name",
+                        "examples": [
+                            "module1"
+                        ],
+                        "description": "The instance name, which is unique inside the cluster."
+                    },
+                    "url": {
+                        "type": "string",
+                        "format": "uri",
+                        "title": "Backend URL",
+                        "description": "The backend target URL."
+                    },
+                    "host": {
+                        "type": "string",
+                        "format": "hostname",
+                        "title": "Virtualhost",
+                        "description": "A fully qualified domain name as virtualhost."
+                    },
+                    "path": {
+                        "type": "string",
+                        "pattern": "^/.*$",
+                        "title": "Request path prefix",
+                        "description": "A path prefix, the matching evaluation will be performed whit and without the trailing slash, eg /foo will match `/foo and `/foo/*, also `/foo/` will match /foo and /foo/*",
+                        "examples": [
+                            "/foo",
+                            "/foo/"
+                        ]
+                    },
+                    "lets_encrypt": {
+                        "type": "boolean",
+                        "title": "Let's Encrypt certificate",
+                        "description": "Request a valid Let's Encrypt certificate."
+                    },
+                    "http2https": {
+                        "type": "boolean",
+                        "title": "HTTP to HTTPS redirection",
+                        "description": "Redirect all the HTTP requests to HTTPS"
+                    },
+                    "strip_prefix": {
+                        "type": "boolean",
+                        "title": "Strip prefix path",
+                        "description": "Strip the path prefix from the request"
+                    },
+                    "skipCertVerify": {
+                        "type": "boolean",
+                        "title": "Skip certificate verification",
+                        "description": "Do not verify the backend's certificate"
+                    },
+                    "user_created": {
+                        "type": "boolean",
+                        "title": "User created route flag",
+                        "description": "If true, the route is flagged as manually created by a user"
+                    },
+                    "headers": {
+                        "type": "object",
+                        "title": "Headers list",
+                        "description": "Headers to add or remove from an HTTP's request or response",
+                        "additionalProperties": false,
+                        "examples": [
+                            {
+                                "headers": {
+                                    "request": {
+                                        "X-foo-add": "foo",
+                                        "X-bar-remove": ""
+                                    },
+                                    "response": {
+                                        "X-bar-add": "bar",
+                                        "X-foo-remove": ""
+                                    }
+                                }
+                            }
+                        ],
+                        "properties": {
+                            "request": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                    "^.+$": {
+                                        "type": "string"
+                                    }
+                                }
+                            },
+                            "response": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                    "^.+$": {
+                                        "type": "string"
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "forward_auth": {
+                        "type": "object",
+                        "required": [
+                            "address"
+                        ],
+                        "title": "Forward Auth configuration",
+                        "description": "If set enabled forwardAuth prop on traefik",
+                        "properties": {
+                            "address": {
+                                "type": "string",
+                                "format": "uri",
+                                "title": "The server address",
+                                "description": "The address option defines the authentication server address"
+                            },
+                            "skip_tls_verify": {
+                                "type": "boolean",
+                                "title": "Skip TLS verify",
+                                "description": "If insecureskipCertVerify is true, the TLS connection to the authentication server accepts any certificate presented by the server regardless of the hostnames it covers"
+                            }
+                        }
+                    }
+                },
+                "required": [
+                    "instance",
+                    "skipCertVerify",
+                    "url",
+                    "http2https",
+                    "user_created"
+                ],
+                "anyOf": [
+                    {
+                        "required": [
+                            "host"
+                        ]
+                    },
+                    {
+                        "required": [
+                            "path"
+                        ]
+                    }
+                ],
+                "dependencies": {
+                    "host": {
+                        "required": [
+                            "lets_encrypt"
+                        ]
+                    },
+                    "strip_prefix": {
+                        "required": [
+                            "path"
+                        ]
+                    }
+                }
+            },
+            {
+                "type": "string",
+                "title": "Name of the route"
+            }
+        ]
     }
 }

--- a/imageroot/actions/set-route/20writeconfig
+++ b/imageroot/actions/set-route/20writeconfig
@@ -35,7 +35,7 @@ serversTransports={}
 # Setup HTTP ans HTTPS routers
 services[data["instance"]] = { "loadBalancer" : { "servers": [{"url": data["url"]}] } }
 # Setup serversTransports if we need to not verify self signed certificates
-if 'skipCertVerify' in data and data["skipCertVerify"]:
+if 'skip_cert_verify' in data and data["skip_cert_verify"]:
     serversTransports[data["instance"]] =  {"insecureSkipVerify": True}
     services[data["instance"]]['loadBalancer']["serversTransport"] = data["instance"]
 
@@ -118,7 +118,7 @@ routers[f'{data["instance"]}-https'] = router_https
 config = {"http": {"services": services, "routers": routers}}
 
 # Add serversTransports if we need to not verify self signed certificates
-if 'skipCertVerify' in data and data["skipCertVerify"]:
+if 'skip_cert_verify' in data and data["skip_cert_verify"]:
     config["http"]["serversTransports"] =  serversTransports
 
 if middlewares:

--- a/imageroot/actions/set-route/20writeconfig
+++ b/imageroot/actions/set-route/20writeconfig
@@ -30,9 +30,14 @@ services = {}
 routers = {}
 router_http = {}
 router_https = {}
+serversTransports={}
 
 # Setup HTTP ans HTTPS routers
 services[data["instance"]] = { "loadBalancer" : { "servers": [{"url": data["url"]}] } }
+# Setup serversTransports if we need to not verify self signed certificates
+if 'skipCertVerify' in data and data["skipCertVerify"]:
+    serversTransports[data["instance"]] =  {"insecureSkipVerify": True}
+    services[data["instance"]]['loadBalancer']["serversTransport"] = data["instance"]
 
 # Remove trailing slash if present
 if data.get("path") is not None:
@@ -111,6 +116,11 @@ if not router_https["middlewares"]:
 routers[f'{data["instance"]}-http'] = router_http
 routers[f'{data["instance"]}-https'] = router_https
 config = {"http": {"services": services, "routers": routers}}
+
+# Add serversTransports if we need to not verify self signed certificates
+if 'skipCertVerify' in data and data["skipCertVerify"]:
+    config["http"]["serversTransports"] =  serversTransports
+
 if middlewares:
     config["http"]["middlewares"] = middlewares
 

--- a/imageroot/actions/set-route/validate-input.json
+++ b/imageroot/actions/set-route/validate-input.json
@@ -42,8 +42,7 @@
     "required": [
         "instance",
         "url",
-        "http2https",
-        "skipCertVerify"
+        "http2https"
     ],
     "anyOf": [
         {

--- a/imageroot/actions/set-route/validate-input.json
+++ b/imageroot/actions/set-route/validate-input.json
@@ -114,7 +114,7 @@
             "title": "Strip prefix path",
             "description": "Strip the path prefix from the request"
         },
-       "skipCertVerify": {
+       "skip_cert_verify": {
             "type": "boolean",
             "title": "Skip certificate verification",
             "description": "Do not verify the backend's certificate"

--- a/imageroot/actions/set-route/validate-input.json
+++ b/imageroot/actions/set-route/validate-input.json
@@ -42,7 +42,8 @@
     "required": [
         "instance",
         "url",
-        "http2https"
+        "http2https",
+        "skipCertVerify"
     ],
     "anyOf": [
         {
@@ -113,6 +114,11 @@
             "type": "boolean",
             "title": "Strip prefix path",
             "description": "Strip the path prefix from the request"
+        },
+       "skipCertVerify": {
+            "type": "boolean",
+            "title": "Skip certificate verification",
+            "description": "Do not verify the backend's certificate"
         },
         "user_created": {
             "type": "boolean",

--- a/imageroot/pypkg/get_route.py
+++ b/imageroot/pypkg/get_route.py
@@ -43,9 +43,9 @@ def get_route(data, ignore_error = False):
 
         # do not verify cert if the service is using a custom certificate
         if 'loadBalancer' in service and 'serversTransport' in service['loadBalancer']:
-            route['skipCertVerify'] = True
+            route['skip_cert_verify'] = True
         else:
-            route['skipCertVerify'] = False
+            route['skip_cert_verify'] = False
 
         # Extract the hostname from the rule of the router
         r =  re.match(r"^.*Host\(`(.*?)`\).*$", traefik_https_route['rule'])

--- a/imageroot/pypkg/get_route.py
+++ b/imageroot/pypkg/get_route.py
@@ -41,6 +41,12 @@ def get_route(data, ignore_error = False):
 
         route['instance'] = data['instance']
 
+        # do not verify cert if the service is using a custom certificate
+        if 'loadBalancer' in service and 'serversTransport' in service['loadBalancer']:
+            route['skipCertVerify'] = True
+        else:
+            route['skipCertVerify'] = False
+
         # Extract the hostname from the rule of the router
         r =  re.match(r"^.*Host\(`(.*?)`\).*$", traefik_https_route['rule'])
         if r:

--- a/tests/10_traefik_routes_api.robot
+++ b/tests/10_traefik_routes_api.robot
@@ -5,19 +5,19 @@ Resource          api.resource
 *** Test Cases ***
 Create a path rule
     ${response} =  Run task    module/traefik1/set-route
-    ...    {"instance": "module1", "url": "http://127.0.0.0:2000", "path": "/foo", "lets_encrypt": false, "http2https": true, "skipCertVerify": true, "headers": {"request": {"X-foo-add": "foo", "X-bar-remove": ""}, "response": {"X-bar-add": "bar", "X-foo-remove": ""}}}
+    ...    {"instance": "module1", "url": "http://127.0.0.0:2000", "path": "/foo", "lets_encrypt": false, "http2https": true, "skip_cert_verify": true, "headers": {"request": {"X-foo-add": "foo", "X-bar-remove": ""}, "response": {"X-bar-add": "bar", "X-foo-remove": ""}}}
 
 Create a host rule
     ${response} =  Run task    module/traefik1/set-route
-    ...    {"instance": "module2", "url": "http://127.0.0.0:2000", "host": "foo.example.org", "lets_encrypt": true, "http2https": true, "skipCertVerify": true, "headers": {"request": {"X-foo-add": "foo", "X-bar-remove": ""}, "response": {"X-bar-add": "bar", "X-foo-remove": ""}}}
+    ...    {"instance": "module2", "url": "http://127.0.0.0:2000", "host": "foo.example.org", "lets_encrypt": true, "http2https": true, "skip_cert_verify": true, "headers": {"request": {"X-foo-add": "foo", "X-bar-remove": ""}, "response": {"X-bar-add": "bar", "X-foo-remove": ""}}}
 
 Create a host & path rule
     ${response} =  Run task    module/traefik1/set-route
-    ...    {"instance": "module3", "url": "http://127.0.0.0:2000", "host": "bar.example.org", "path": "/bar", "lets_encrypt": true, "http2https": true, "skipCertVerify": true, "user_created": true, "headers": {"request": {"X-foo-add": "foo", "X-bar-remove": ""}, "response": {"X-bar-add": "bar", "X-foo-remove": ""}}}
+    ...    {"instance": "module3", "url": "http://127.0.0.0:2000", "host": "bar.example.org", "path": "/bar", "lets_encrypt": true, "http2https": true, "skip_cert_verify": true, "user_created": true, "headers": {"request": {"X-foo-add": "foo", "X-bar-remove": ""}, "response": {"X-bar-add": "bar", "X-foo-remove": ""}}}
 
 Create an invalid path route
     Run Keyword And Expect Error    *    Run task    module/traefik1/set-route
-    ...    {"instance": "module4", "url": "http://127.0.0.0:2000", "path": "bar", "lets_encrypt": true, "http2https": true, "skipCertVerify": true, "headers": {"request": {"X-foo-add": "foo", "X-bar-remove": ""}, "response": {"X-bar-add": "bar", "X-foo-remove": ""}}}
+    ...    {"instance": "module4", "url": "http://127.0.0.0:2000", "path": "bar", "lets_encrypt": true, "http2https": true, "skip_cert_verify": true, "headers": {"request": {"X-foo-add": "foo", "X-bar-remove": ""}, "response": {"X-bar-add": "bar", "X-foo-remove": ""}}}
 
 Get path route
     ${response} =  Run task    module/traefik1/get-route    {"instance": "module1"}
@@ -26,7 +26,7 @@ Get path route
     Should Be Equal As Strings    ${response['url']}              http://127.0.0.0:2000
     Should Be Equal As Strings    ${response['lets_encrypt']}    False
     Should Be Equal As Strings    ${response['http2https']}      True
-    Should Be Equal As Strings    ${response['skipCertVerify']}  True
+    Should Be Equal As Strings    ${response['skip_cert_verify']}  True
     Should Be Equal As Strings    ${response['strip_prefix']}    False
     Should Be Equal As Strings    ${response['user_created']}    False
     Should Be Equal As Strings    ${response['headers']['request']['X-foo-add']}    foo
@@ -41,7 +41,7 @@ Get host route
     Should Be Equal As Strings    ${response['url']}             http://127.0.0.0:2000
     Should Be Equal As Strings    ${response['lets_encrypt']}    True
     Should Be Equal As Strings    ${response['http2https']}      True
-    Should Be Equal As Strings    ${response['skipCertVerify']}  True
+    Should Be Equal As Strings    ${response['skip_cert_verify']}  True
     Should Be Equal As Strings    ${response['user_created']}    False
     Should Be Equal As Strings    ${response['headers']['request']['X-foo-add']}    foo
     Should Be Equal As Strings    ${response['headers']['request']['X-bar-remove']}    ${EMPTY}
@@ -57,7 +57,7 @@ Get host & path route
     Should Be Equal As Strings    ${response['url']}              http://127.0.0.0:2000
     Should Be Equal As Strings    ${response['lets_encrypt']}    True
     Should Be Equal As Strings    ${response['http2https']}      True
-    Should Be Equal As Strings    ${response['skipCertVerify']}  True
+    Should Be Equal As Strings    ${response['skip_cert_verify']}  True
     Should Be Equal As Strings    ${response['strip_prefix']}    False
     Should Be Equal As Strings    ${response['user_created']}    True
     Should Be Equal As Strings    ${response['headers']['request']['X-foo-add']}    foo
@@ -78,7 +78,7 @@ Get expanded routes list
     Should Be Equal As Strings    ${response[0]['url']}              http://127.0.0.0:2000
     Should Be Equal As Strings    ${response[0]['lets_encrypt']}    False
     Should Be Equal As Strings    ${response[0]['http2https']}      True
-    Should Be Equal As Strings    ${response[0]['skipCertVerify']}  True
+    Should Be Equal As Strings    ${response[0]['skip_cert_verify']}  True
     Should Be Equal As Strings    ${response[0]['strip_prefix']}    False
     Should Be Equal As Strings    ${response[0]['user_created']}    False
     Should Be Equal As Strings    ${response[0]['headers']['request']['X-foo-add']}    foo
@@ -92,7 +92,7 @@ Get expanded routes list
     Should Be Equal As Strings    ${response[1]['url']}             http://127.0.0.0:2000
     Should Be Equal As Strings    ${response[1]['lets_encrypt']}    True
     Should Be Equal As Strings    ${response[1]['http2https']}      True
-    Should Be Equal As Strings    ${response[1]['skipCertVerify']}  True
+    Should Be Equal As Strings    ${response[1]['skip_cert_verify']}  True
     Should Be Equal As Strings    ${response[1]['user_created']}    False
     Should Be Equal As Strings    ${response[1]['headers']['request']['X-foo-add']}    foo
     Should Be Equal As Strings    ${response[1]['headers']['request']['X-bar-remove']}    ${EMPTY}
@@ -106,7 +106,7 @@ Get expanded routes list
     Should Be Equal As Strings    ${response[2]['url']}              http://127.0.0.0:2000
     Should Be Equal As Strings    ${response[2]['lets_encrypt']}    True
     Should Be Equal As Strings    ${response[2]['http2https']}      True
-    Should Be Equal As Strings    ${response[2]['skipCertVerify']}  True
+    Should Be Equal As Strings    ${response[2]['skip_cert_verify']}  True
     Should Be Equal As Strings    ${response[2]['strip_prefix']}    False
     Should Be Equal As Strings    ${response[2]['user_created']}    True
     Should Be Equal As Strings    ${response[2]['headers']['request']['X-foo-add']}    foo

--- a/tests/10_traefik_routes_api.robot
+++ b/tests/10_traefik_routes_api.robot
@@ -5,19 +5,19 @@ Resource          api.resource
 *** Test Cases ***
 Create a path rule
     ${response} =  Run task    module/traefik1/set-route
-    ...    {"instance": "module1", "url": "http://127.0.0.0:2000", "path": "/foo", "lets_encrypt": false, "http2https": true, "headers": {"request": {"X-foo-add": "foo", "X-bar-remove": ""}, "response": {"X-bar-add": "bar", "X-foo-remove": ""}}}
+    ...    {"instance": "module1", "url": "http://127.0.0.0:2000", "path": "/foo", "lets_encrypt": false, "http2https": true, "skipCertVerify": true, "headers": {"request": {"X-foo-add": "foo", "X-bar-remove": ""}, "response": {"X-bar-add": "bar", "X-foo-remove": ""}}}
 
 Create a host rule
     ${response} =  Run task    module/traefik1/set-route
-    ...    {"instance": "module2", "url": "http://127.0.0.0:2000", "host": "foo.example.org", "lets_encrypt": true, "http2https": true, "headers": {"request": {"X-foo-add": "foo", "X-bar-remove": ""}, "response": {"X-bar-add": "bar", "X-foo-remove": ""}}}
+    ...    {"instance": "module2", "url": "http://127.0.0.0:2000", "host": "foo.example.org", "lets_encrypt": true, "http2https": true, "skipCertVerify": true, "headers": {"request": {"X-foo-add": "foo", "X-bar-remove": ""}, "response": {"X-bar-add": "bar", "X-foo-remove": ""}}}
 
 Create a host & path rule
     ${response} =  Run task    module/traefik1/set-route
-    ...    {"instance": "module3", "url": "http://127.0.0.0:2000", "host": "bar.example.org", "path": "/bar", "lets_encrypt": true, "http2https": true, "user_created": true, "headers": {"request": {"X-foo-add": "foo", "X-bar-remove": ""}, "response": {"X-bar-add": "bar", "X-foo-remove": ""}}}
+    ...    {"instance": "module3", "url": "http://127.0.0.0:2000", "host": "bar.example.org", "path": "/bar", "lets_encrypt": true, "http2https": true, "skipCertVerify": true, "user_created": true, "headers": {"request": {"X-foo-add": "foo", "X-bar-remove": ""}, "response": {"X-bar-add": "bar", "X-foo-remove": ""}}}
 
 Create an invalid path route
     Run Keyword And Expect Error    *    Run task    module/traefik1/set-route
-    ...    {"instance": "module4", "url": "http://127.0.0.0:2000", "path": "bar", "lets_encrypt": true, "http2https": true, "headers": {"request": {"X-foo-add": "foo", "X-bar-remove": ""}, "response": {"X-bar-add": "bar", "X-foo-remove": ""}}}
+    ...    {"instance": "module4", "url": "http://127.0.0.0:2000", "path": "bar", "lets_encrypt": true, "http2https": true, "skipCertVerify": true, "headers": {"request": {"X-foo-add": "foo", "X-bar-remove": ""}, "response": {"X-bar-add": "bar", "X-foo-remove": ""}}}
 
 Get path route
     ${response} =  Run task    module/traefik1/get-route    {"instance": "module1"}
@@ -26,6 +26,7 @@ Get path route
     Should Be Equal As Strings    ${response['url']}              http://127.0.0.0:2000
     Should Be Equal As Strings    ${response['lets_encrypt']}    False
     Should Be Equal As Strings    ${response['http2https']}      True
+    Should Be Equal As Strings    ${response['skipCertVerify']}  True
     Should Be Equal As Strings    ${response['strip_prefix']}    False
     Should Be Equal As Strings    ${response['user_created']}    False
     Should Be Equal As Strings    ${response['headers']['request']['X-foo-add']}    foo
@@ -40,6 +41,7 @@ Get host route
     Should Be Equal As Strings    ${response['url']}             http://127.0.0.0:2000
     Should Be Equal As Strings    ${response['lets_encrypt']}    True
     Should Be Equal As Strings    ${response['http2https']}      True
+    Should Be Equal As Strings    ${response['skipCertVerify']}  True
     Should Be Equal As Strings    ${response['user_created']}    False
     Should Be Equal As Strings    ${response['headers']['request']['X-foo-add']}    foo
     Should Be Equal As Strings    ${response['headers']['request']['X-bar-remove']}    ${EMPTY}
@@ -55,6 +57,7 @@ Get host & path route
     Should Be Equal As Strings    ${response['url']}              http://127.0.0.0:2000
     Should Be Equal As Strings    ${response['lets_encrypt']}    True
     Should Be Equal As Strings    ${response['http2https']}      True
+    Should Be Equal As Strings    ${response['skipCertVerify']}  True
     Should Be Equal As Strings    ${response['strip_prefix']}    False
     Should Be Equal As Strings    ${response['user_created']}    True
     Should Be Equal As Strings    ${response['headers']['request']['X-foo-add']}    foo
@@ -75,6 +78,7 @@ Get expanded routes list
     Should Be Equal As Strings    ${response[0]['url']}              http://127.0.0.0:2000
     Should Be Equal As Strings    ${response[0]['lets_encrypt']}    False
     Should Be Equal As Strings    ${response[0]['http2https']}      True
+    Should Be Equal As Strings    ${response[0]['skipCertVerify']}  True
     Should Be Equal As Strings    ${response[0]['strip_prefix']}    False
     Should Be Equal As Strings    ${response[0]['user_created']}    False
     Should Be Equal As Strings    ${response[0]['headers']['request']['X-foo-add']}    foo
@@ -88,6 +92,7 @@ Get expanded routes list
     Should Be Equal As Strings    ${response[1]['url']}             http://127.0.0.0:2000
     Should Be Equal As Strings    ${response[1]['lets_encrypt']}    True
     Should Be Equal As Strings    ${response[1]['http2https']}      True
+    Should Be Equal As Strings    ${response[1]['skipCertVerify']}  True
     Should Be Equal As Strings    ${response[1]['user_created']}    False
     Should Be Equal As Strings    ${response[1]['headers']['request']['X-foo-add']}    foo
     Should Be Equal As Strings    ${response[1]['headers']['request']['X-bar-remove']}    ${EMPTY}
@@ -101,6 +106,7 @@ Get expanded routes list
     Should Be Equal As Strings    ${response[2]['url']}              http://127.0.0.0:2000
     Should Be Equal As Strings    ${response[2]['lets_encrypt']}    True
     Should Be Equal As Strings    ${response[2]['http2https']}      True
+    Should Be Equal As Strings    ${response[2]['skipCertVerify']}  True
     Should Be Equal As Strings    ${response[2]['strip_prefix']}    False
     Should Be Equal As Strings    ${response[2]['user_created']}    True
     Should Be Equal As Strings    ${response[2]['headers']['request']['X-foo-add']}    foo


### PR DESCRIPTION
This pull request adds the `serversTransports` configuration to support self-signed certificate verification. It also adds the `skip_cert_verify` flag to the `get_route` function for handling custom certificates.

we look in services if exists to set to true `skip_cert_verify`  :  `"serversTransport": "backuppc@file"`
```
  {
    "loadBalancer": {
      "servers": [
        {
          "url": "https://192.168.12.15:443"
        }
      ],
      "passHostHeader": true,
      "serversTransport": "backuppc@file"
    },
    "status": "enabled",
    "usedBy": [
      "backuppc-http@file",
      "backuppc-https@file"
    ],
    "serverStatus": {
      "https://192.168.12.15:443": "UP"
    },
    "name": "backuppc@file",
    "provider": "file",
    "type": "loadbalancer"
  },
}
```

if `skipCertVerify` is true then we write to dynamic configuration 

```
http:
  services:
    backuppc:
      loadBalancer:
+        serversTransport: backuppc
        servers:
        - url: https://192.168.12.15
+  serversTransports:
+    backuppc:
+      insecureSkipVerify: true
```      


I took the liberty to write a json schema for list-route, I took from set-route

https://github.com/NethServer/dev/issues/6822