### PR TITLE
Add pattern validation for instance name

### DIFF
--- a/imageroot/actions/set-route/validate-input.json
+++ b/imageroot/actions/set-route/validate-input.json
@@ -71,6 +71,7 @@
     "properties": {
         "instance": {
             "type": "string",
+            "pattern": "^[a-zA-Z0-9_-]+$",
             "title": "Instance name",
             "examples": [
                 "module1"


### PR DESCRIPTION
This pull request adds pattern validation for the instance name in the `validate-input.json` file. The pattern ensures that the instance name only contains alphanumeric characters, underscores, and hyphens. This validation helps to ensure data integrity and prevent any potential issues with the instance name.