### PR TITLE
add dot in set-route validation

### DIFF
--- a/imageroot/actions/set-route/validate-input.json
+++ b/imageroot/actions/set-route/validate-input.json
@@ -71,7 +71,7 @@
     "properties": {
         "instance": {
             "type": "string",
-            "pattern": "^[a-zA-Z0-9_-]+$",
+            "pattern": "^[a-zA-Z0-9_\\.-]+$",
             "title": "Instance name",
             "examples": [
                 "module1"


### PR DESCRIPTION
With webserver we need to create uniq instance name for route, something like `webserver1-www.foo.org`, the PR https://github.com/NethServer/ns8-traefik/pull/50 has introduced a pattern validation to forbid some characters, we need to relax a bit

https://github.com/NethServer/dev/issues/6849