### PR TITLE
Add pattern validation for virtualhost

### DIFF
--- a/imageroot/actions/set-route/validate-input.json
+++ b/imageroot/actions/set-route/validate-input.json
@@ -87,6 +87,7 @@
         "host": {
             "type": "string",
             "format": "hostname",
+            "pattern": "\\.",
             "title": "Virtualhost",
             "description": "A fully qualified domain name as virtualhost."
         },


### PR DESCRIPTION
This pull request adds pattern validation for the virtualhost field in the validate-input.json file. The pattern ensures that the virtualhost is a fully qualified domain name.

https://github.com/NethServer/dev/issues/6853