### PR TITLE
Avoid SIGKILL at shutdown

### DIFF
--- a/imageroot/systemd/user/traefik.service
+++ b/imageroot/systemd/user/traefik.service
@@ -22,7 +22,7 @@ ExecStart=/usr/bin/podman run \
     --volume=./custom_certificates:/etc/traefik/custom_certificates:Z \
     ${TRAEFIK_IMAGE}
 ExecStartPost=runagent write-hosts
-ExecStop=/usr/bin/podman stop --ignore --cidfile %t/traefik.ctr-id -t 10
+ExecStop=/usr/bin/podman stop --ignore --cidfile %t/traefik.ctr-id -t 15
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/traefik.ctr-id
 PIDFile=%t/traefik.pid
 Type=forking


### PR DESCRIPTION
The default `lifeCycle.graceTimeOut` is 10 seconds and races with Podman stop period: increase Podman wait, to avoid killing Traefik with signal 9.


```
May 03 08:35:16 rl1.dp.nethserver.net systemd[30247]: Stopping Traefik edge proxy...
May 03 08:35:16 rl1.dp.nethserver.net traefik[39585]: time="2024-05-03T08:35:16Z" level=info msg="I have to go..."
May 03 08:35:16 rl1.dp.nethserver.net traefik[39585]: time="2024-05-03T08:35:16Z" level=info msg="Stopping server gracefully"
May 03 08:35:16 rl1.dp.nethserver.net traefik[39585]: time="2024-05-03T08:35:16Z" level=error msg="accept tcp [::]:443: use of closed network connection" entryPointName=https
May 03 08:35:16 rl1.dp.nethserver.net traefik[39585]: time="2024-05-03T08:35:16Z" level=error msg="accept tcp [::]:80: use of closed network connection" entryPointName=http
May 03 08:35:16 rl1.dp.nethserver.net traefik[39585]: time="2024-05-03T08:35:16Z" level=error msg="Error while starting server: accept tcp [::]:80: use of closed network connection" entryPoi>
May 03 08:35:16 rl1.dp.nethserver.net traefik[39585]: time="2024-05-03T08:35:16Z" level=error msg="Error while starting server: accept tcp [::]:443: use of closed network connection" entryPo>
May 03 08:35:26 rl1.dp.nethserver.net traefik[39585]: time="2024-05-03T08:35:26Z" level=info msg="Server stopped"
May 03 08:35:26 rl1.dp.nethserver.net traefik[39585]: time="2024-05-03T08:35:26Z" level=info msg="Shutting down"
May 03 08:35:26 rl1.dp.nethserver.net traefik[39585]: 80.17.99.73 - - [03/May/2024:08:34:26 +0000] "GET /cluster-admin/ws HTTP/1.1" 0 0 "-" "-" 125 "ApiServer-https@file" "http://127.0.0.1:9>
May 03 08:35:26 rl1.dp.nethserver.net traefik1[39736]: time="2024-05-03T08:35:26Z" level=warning msg="StopSignal SIGTERM failed to stop container traefik in 10 seconds, resorting to SIGKILL"
May 03 08:35:26 rl1.dp.nethserver.net conmon[39585]: conmon 42a3e3222a19daf1ba16 <nwarn>: Failed to open cgroups file: /sys/fs/cgroup/user.slice/user-1001.slice/user@1001.service/user.slice/>
May 03 08:35:26 rl1.dp.nethserver.net traefik1[39736]: 42a3e3222a19daf1ba169ec671c7990134ac3ce26bd479f24451bc8c43d42ff0
May 03 08:35:26 rl1.dp.nethserver.net traefik1[39755]: 42a3e3222a19daf1ba169ec671c7990134ac3ce26bd479f24451bc8c43d42ff0
May 03 08:35:26 rl1.dp.nethserver.net systemd[30247]: Stopped Traefik edge proxy.
```

Refs https://github.com/NethServer/dev/issues/6912

See also https://doc.traefik.io/traefik/routing/entrypoints/#lifecycle