### PR TITLE
Add validation for uploaded key type

### DIFF
--- a/imageroot/actions/upload-certificate/21validate_certificates
+++ b/imageroot/actions/upload-certificate/21validate_certificates
@@ -9,13 +9,26 @@ set -e
 
 CERT_FILE=uploaded_cert
 KEY_FILE=uploaded_key
+VALID_KEY=0
+TYPE_KEY=""
 
 del_certs() {
     rm -f $KEY_FILE $CERT_FILE
 }
 
 # checking if key is valid
-if ! openssl rsa -check -in $KEY_FILE >/dev/null 2>&1; then
+if openssl rsa -check -in $KEY_FILE >/dev/null 2>&1; then
+    VALID_KEY=1
+    TYPE_KEY="rsa"
+elif openssl dsa -check -in $KEY_FILE >/dev/null 2>&1; then
+    VALID_KEY=1
+    TYPE_KEY="dsa"
+elif openssl ec -check -in $KEY_FILE >/dev/null 2>&1; then
+    VALID_KEY=1
+    TYPE_KEY="ec"
+fi
+
+if [ $VALID_KEY -eq 0 ]; then
     echo "Key validation failed."
     del_certs
     exit 2
@@ -30,7 +43,7 @@ fi
 
 # check if cert is provided by key
 cert_hash="$(openssl x509 -noout -modulus -in $CERT_FILE | openssl md5)"
-key_hash="$(openssl rsa -noout -modulus -in $KEY_FILE | openssl md5)"
+key_hash="$(openssl $TYPE_KEY -noout -modulus -in $KEY_FILE | openssl md5)"
 if [ "$cert_hash" != "$key_hash" ]; then
     echo "Key didn't generate certificate."
     del_certs


### PR DESCRIPTION
This pull request adds validation for the type of uploaded key in the `upload-certificate` action. It checks if the key is valid and determines its type (rsa, dsa, or ec). If the key is not valid, the validation fails and the certificates are deleted. This ensures that only valid keys are accepted in the upload process.

https://github.com/NethServer/dev/issues/6937