### PR TITLE
Compare md5 of public keys for certificate validation

### DIFF
--- a/imageroot/actions/upload-certificate/21validate_certificates
+++ b/imageroot/actions/upload-certificate/21validate_certificates
@@ -41,10 +41,12 @@ if ! openssl x509 -text -noout -in $CERT_FILE >/dev/null 2>&1; then
     exit 4
 fi
 
-# check if cert is provided by key
-cert_hash="$(openssl x509 -noout -modulus -in $CERT_FILE | openssl md5)"
-key_hash="$(openssl $TYPE_KEY -noout -modulus -in $KEY_FILE | openssl md5)"
-if [ "$cert_hash" != "$key_hash" ]; then
+# check if cert is provided by key (we compare md5 of public keys)
+cert_public_key="$(openssl x509 -noout -pubkey -in  $CERT_FILE | openssl md5)"
+key_public_key="$(openssl  pkey -pubout -in $KEY_FILE | openssl md5)"
+
+
+if [ "$cert_public_key" != "$key_public_key" ]; then
     echo "Key didn't generate certificate."
     del_certs
     exit 3


### PR DESCRIPTION
This pull request adds a new feature to compare the md5 of public keys for certificate validation. Previously, the certificate and key were compared using their md5 hashes, but now we compare the md5 hashes of their public keys instead.

This is needed because we cannot use the modulus with dsa and ec certificates : see https://github.com/NethServer/dev/issues/6937#issuecomment-2137084954

https://github.com/NethServer/dev/issues/6937