### PR TITLE
upload-certificate: improve validation step output

### DIFF
--- a/imageroot/actions/upload-certificate/21validate_certificates
+++ b/imageroot/actions/upload-certificate/21validate_certificates
@@ -29,14 +29,18 @@ elif openssl ec -check -in $KEY_FILE >/dev/null 2>&1; then
 fi
 
 if [ $VALID_KEY -eq 0 ]; then
-    echo "Key validation failed."
+    echo "Key validation failed." 1>&2
+    echo "set-status validation-failed" >&${AGENT_COMFD:-2}
+    printf '{"field":"keyFile","parameter":"keyFile","value":"","error":"invalid_key"}\n'
     del_certs
     exit 2
 fi
 
 # check if certificate is properly pam formatted
 if ! openssl x509 -text -noout -in $CERT_FILE >/dev/null 2>&1; then
-    echo "Certificate not well formatted."
+    echo "Certificate not well formatted." 1>&2
+    echo "set-status validation-failed" >&${AGENT_COMFD:-2}
+    printf '{"field":"certFile","parameter":"certFile","value":"","error":"invalid_format"}\n'
     del_certs
     exit 4
 fi
@@ -44,7 +48,9 @@ fi
 # check it the common name is present and is not empty
 cn_name=$(openssl x509 -noout -subject -nameopt=multiline -in $CERT_FILE | sed -n 's/ *commonName *= //p')
 if [ -z "$cn_name" ]; then
-    echo "Certificate doesn't have a common name."
+    echo "Certificate doesn't have a common name." 1>&2
+    echo "set-status validation-failed" >&${AGENT_COMFD:-2}
+    printf '{"field":"certFile","parameter":"certFile","value":"","error":"empty_common_name"}\n'
     del_certs
     exit 5
 fi
@@ -55,7 +61,9 @@ key_public_key="$(openssl  pkey -pubout -in $KEY_FILE | openssl md5)"
 
 
 if [ "$cert_public_key" != "$key_public_key" ]; then
-    echo "Key didn't generate certificate."
+    echo "Key didn't generate certificate." 1>&2
+    echo "set-status validation-failed" >&${AGENT_COMFD:-2}
+    printf '{"field":"certFile","parameter":"certFile","value":"","error":"key_mismatch"}\n'
     del_certs
     exit 3
 fi


### PR DESCRIPTION
To make the validation step more usable from the UI, the following improvements are made:

* Redirect non-JSON error messages to stderr
* Properly signal a validation error to the agent
* Print a properly formatted JSON error message to stdout in case of validation failure

https://github.com/NethServer/dev/issues/6986