### PR TITLE
feat(phonehome): add get-facts

### DIFF
--- a/imageroot/actions/get-facts/50facts
+++ b/imageroot/actions/get-facts/50facts
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# Count routes and certificates
+
+import json
+import os
+import sys
+import urllib.request
+from get_route import get_route
+from custom_certificate_manager import list_custom_certificates
+from get_certificate import get_certificate
+
+api_path = os.environ["API_PATH"]
+
+try:
+    with urllib.request.urlopen(f'http://127.0.0.1/{api_path}/api/http/routers') as res:
+        traefik_routes = json.load(res)
+except urllib.error.URLError as e:
+    raise Exception(f'Error reaching traefik daemon: {e.reason}')
+
+info = {"custom_path_routes": 0, "custom_host_routes": 0, "custom_certificates": 0, "acme_manual_certificates": 0, "acme_auto_certificates": 0, "acme_failed_certificates": 0}
+
+for route in traefik_routes:
+    # List routes
+    if route['name'].endswith('-https@file'):
+        route['name'] = route['name'].removesuffix('-https@file')
+        if route == "ApiServer":
+            continue
+        r = get_route({'instance': route['name']})
+        if r.get('user_created', False):
+            if r.get('path'):
+                info["custom_path_routes"] += 1
+            if r.get('host'):
+                info["custom_host_routes"] += 1
+
+    # List acme certificates
+    if "certResolver" in route.get("tls", {}) and route['status'] == 'enabled':
+        cert = get_certificate({'name': route['name']})
+        if cert.get('type') == 'internal':
+            info["acme_manual_certificates"] += 1
+        else:
+            info["acme_auto_certificates"] += 1
+        if 'obtained' in cert and not cert["obtained"]:
+            info["acme_failed_certificates"] += 1
+
+# Retrieve custom certificate
+info["custom_certificates"] = len(list_custom_certificates())
+
+json.dump(info, fp=sys.stdout)


### PR DESCRIPTION
List the following info:
    
- number of path-based custom routes
- number of host-bases custom routes
- number of custom/uploaded certificates
- number of acme manual certificates
- number of acme automatic certificates
- number of acme failed certificates

JSON example:
```json
      {
        "id": "traefik1",
        "version": "2.2.5",
        "name": "traefik",
        "node": "1",
        "custom_path_routes": 1,
        "custom_host_routes": 1,
        "custom_certificates": 1,
        "acme_manual_certificates": 2,
        "acme_auto_certificates": 1,
        "acme_failed_certificates": 1
      }
```

See:
- NethServer/ns8-core#784
- NethServer/dev#7274