### PR TITLE
feat: pass custom args to Podman

### DIFF
--- a/imageroot/systemd/user/traefik.service
+++ b/imageroot/systemd/user/traefik.service
@@ -20,6 +20,7 @@ ExecStart=/usr/bin/podman run \
     --volume=./selfsigned.key:/etc/traefik/selfsigned.key:z \
     --volume=./configs:/etc/traefik/configs:z \
     --volume=./custom_certificates:/etc/traefik/custom_certificates:z \
+    $PODMAN_RUN_OPTS \
     ${TRAEFIK_IMAGE}
 ExecStartPost=-runagent write-hosts
 ExecStop=/usr/bin/podman stop --ignore --cidfile %t/traefik.ctr-id -t 15


### PR DESCRIPTION
The PODMAN_RUN_OPTS environment variable can be set to custom values. For example it can be used to set an additional environment variable for Traefik runtime, like LEGO_CA_CERTIFICATES.

Refs NethServer/dev#7300