### PR TITLE
feat: add IPAllowList to route management

### DIFF
--- a/imageroot/actions/get-route/validate-output.json
+++ b/imageroot/actions/get-route/validate-output.json
@@ -136,6 +136,13 @@
             "title": "User created route flag",
             "description": "If true, the route is flagged as manually created by a user"
         },
+        "ip_allowlist": {
+            "type":"array",
+            "description": "List of allowed client ip addresses, in CIDR format",
+            "items": {
+                "type":"string"
+            }
+        },
         "headers": {
             "type": "object",
             "title": "Headers list",

--- a/imageroot/actions/set-route/10validate
+++ b/imageroot/actions/set-route/10validate
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+import os
+import agent
+import ipaddress
+
+def main():
+    agent.set_weight(os.path.basename(__file__), 0) # Validation step, no task progress at all
+    request = json.load(sys.stdin)
+    if "ip_allowlist" in request:
+        for ipvalue in request['ip_allowlist']:
+            # Check if ipvalue is a string representing IPv4, IPv6, or
+            # CIDR:
+            try:
+                if '/' in ipvalue:
+                    # CIDR validation
+                    ipaddress.ip_network(ipvalue, strict=False)
+                else:
+                    # IP validation
+                    ipaddress.ip_address(ipvalue)
+            except ValueError:
+                agent.set_status('validation-failed')
+                json.dump([{'field':'ip_allowlist','parameter':'ip_allowlist','value': ipvalue,'error':'bad_ip_address'}], fp=sys.stdout)
+                sys.exit(3)
+
+if __name__ == "__main__":
+    main()

--- a/imageroot/actions/set-route/20writeconfig
+++ b/imageroot/actions/set-route/20writeconfig
@@ -71,6 +71,22 @@ if data.get("host") is not None:
     if data["lets_encrypt"]:
         router_https["tls"]["certresolver"] = "acmeServer"
 
+# IP addresses allowed to use the router
+if data.get('ip_allowlist', []) != []:
+    middlewares[f'{data["instance"]}-ipallowlist'] = {
+        "ipAllowList": {
+            "sourceRange": data['ip_allowlist'],
+            # If X-Forwarded-For header is present skip PROXIES_DEPTH
+            # items to extrapolate the Client IP. See set-trusted-proxies
+            # action.
+            "ipStrategy": {
+                "depth": '{{ env "PROXIES_DEPTH" | default "0"}}',
+            }
+        },
+    }
+    router_http["middlewares"].append(f'{data["instance"]}-ipallowlist')
+    router_https["middlewares"].append(f'{data["instance"]}-ipallowlist')
+
 # Strip the path from the request
 if data.get("strip_prefix"):
     middlewares[f'{data["instance"]}-stripprefix'] = { "stripPrefix": { "prefixes": path } }

--- a/imageroot/actions/set-route/validate-input.json
+++ b/imageroot/actions/set-route/validate-input.json
@@ -27,6 +27,17 @@
             "http2https": true
         },
         {
+            "instance": "module3",
+            "url": "http://127.0.0.0:2000",
+            "path": "/foo",
+            "lets_encrypt": true,
+            "http2https": true,
+            "ip_allowlist": [
+                "192.168.13.0/24",
+                "10.12.21.3"
+            ]
+        },
+        {
             "instance": "module1",
             "url": "http://127.0.0.0:2000",
             "host": "module.example.org",
@@ -125,6 +136,13 @@
             "type": "boolean",
             "title": "User created route flag",
             "description": "If true, the route is flagged as manually created by a user"
+        },
+        "ip_allowlist": {
+            "type":"array",
+            "description": "List of allowed client ip addresses, in CIDR format",
+            "items": {
+                "type":"string"
+            }
         },
         "headers": {
             "type": "object",

--- a/imageroot/pypkg/get_route.py
+++ b/imageroot/pypkg/get_route.py
@@ -107,6 +107,19 @@ def get_route(data, ignore_error = False):
                 # The TLS skip certificate verification flag may be missing completely: ignore.
                 pass
 
+        if middlewares and f'{module}-ipallowlist' in middlewares:
+            try:
+                with urllib.request.urlopen(f'http://127.0.0.1/{api_path}/api/http/middlewares/{module}-ipallowlist@file') as res:
+                    ipallowlist_middleware = json.load(res)
+            except urllib.error.HTTPError as e:
+                raise Exception(f'Error reaching traefik daemon (middlewares): {e.reason}')
+
+            try:
+                route['ip_allowlist'] = ipallowlist_middleware['ipAllowList']['sourceRange']
+            except KeyError:
+                # ipAllowList not defined, skip
+                pass
+
     except urllib.error.HTTPError as e:
         if e.code == 404:
             # If the route is not found, return an empty JSON object


### PR DESCRIPTION
Optionally specify the list of IPv4/v6 addresses that are authorized to connect with the service exposed by the route.

The configuration relies on the environment variable PROXIES_DEPTH, which is set by another action, `set-trusted-proxies` (see PR #78), and included with a Go template as a reference.

Refs https://github.com/NethServer/dev/issues/7312