### PR TITLE
feat: set-route patch behavior

### DIFF
--- a/imageroot/actions/set-route/20writeconfig
+++ b/imageroot/actions/set-route/20writeconfig
@@ -16,10 +16,14 @@ import sys
 import os
 import yaml
 import copy
+import agent
+from get_route import get_route
 
 # Try to parse the stdin as JSON.
 # If parsing fails, output everything to stderr
-data = json.load(sys.stdin)
+request = json.load(sys.stdin)
+data = get_route({"instance": request["instance"]})
+data.update(request)
 
 agent_id = os.getenv("AGENT_ID", "")
 if not agent_id:
@@ -33,6 +37,11 @@ routers = {}
 router_http = {}
 router_https = {}
 serversTransports={}
+
+if not 'url' in data:
+    agent.set_status('validation-failed')
+    json.dump([{'field':'url', 'parameter':'url', 'value': '', 'error':'missing_url_argument'}], fp=sys.stdout)
+    sys.exit(4)
 
 # Setup HTTP ans HTTPS routers
 services[data["instance"]] = { "loadBalancer" : { "servers": [{"url": data["url"]}] } }
@@ -53,8 +62,12 @@ if data.get("host") is not None and data.get("path") is not None:
     route = { "rule" :  f'Host(`{data["host"]}`) && (Path(`{path}`) || PathPrefix(`{path_prefix}`))', "priority": data.get('priority', 3) }
 elif data.get("host") is not None:
     route = { "rule":  f'Host(`{data["host"]}`)', "priority": data.get('priority', 2)}
-else:
+elif data.get("path") is not None:
     route = { "rule": f'Path(`{path}`) || PathPrefix(`{path_prefix}`)', "priority": data.get('priority', 1)}
+else:
+    agent.set_status('validation-failed')
+    json.dump([{'field':'path', 'parameter':'path', 'value': '', 'error':'missing_path_argument'}], fp=sys.stdout)
+    sys.exit(4)
 
 # Setup routers
 route["service"] = data["instance"]
@@ -134,7 +147,7 @@ if "headers" in data and data["headers"]:
     router_https["middlewares"].append(f'{data["instance"]}-headers')
 
 # Enable or disable HTTP 2 HTTPS redirection
-if data["http2https"]:
+if data.get("http2https"):
     router_http["middlewares"] = ["http2https-redirectscheme"]
 
 # Cleanup middleware pointers

--- a/imageroot/actions/set-route/validate-input.json
+++ b/imageroot/actions/set-route/validate-input.json
@@ -59,34 +59,8 @@
     ],
     "type": "object",
     "required": [
-        "instance",
-        "url",
-        "http2https"
+        "instance"
     ],
-    "anyOf": [
-        {
-            "required": [
-                "host"
-            ]
-        },
-        {
-            "required": [
-                "path"
-            ]
-        }
-    ],
-    "dependencies": {
-        "host": {
-            "required": [
-                "lets_encrypt"
-            ]
-        },
-        "strip_prefix": {
-            "required": [
-                "path"
-            ]
-        }
-    },
     "properties": {
         "instance": {
             "type": "string",
@@ -121,7 +95,7 @@
             ]
         },
         "priority": {
-            "type":"integer",
+            "type": "integer",
             "description": "Override the default priority assignment (1,2,3), based on host and path",
             "minimum": 0
         },
@@ -145,7 +119,7 @@
             "title": "Slash redirect",
             "description": "Redirect to path with trailing slash"
         },
-       "skip_cert_verify": {
+        "skip_cert_verify": {
             "type": "boolean",
             "title": "Skip certificate verification",
             "description": "Do not verify the backend's certificate"
@@ -156,10 +130,10 @@
             "description": "If true, the route is flagged as manually created by a user"
         },
         "ip_allowlist": {
-            "type":"array",
+            "type": "array",
             "description": "List of allowed client ip addresses, in CIDR format",
             "items": {
-                "type":"string"
+                "type": "string"
             }
         },
         "headers": {
@@ -203,12 +177,17 @@
             }
         },
         "forward_auth": {
-            "type": "object",
-            "required": [
-                "address"
+            "type": [
+                "object"
             ],
+            "dependencies": {
+                "skip_tls_verify": [
+                    "address"
+                ]
+            },
             "title": "Forward Auth configuration",
-            "description": "If set enabled forwardAuth prop on traefik",
+            "description": "If set enabled forwardAuth prop on traefik. If null",
+            "additionalProperties": false,
             "properties": {
                 "address": {
                     "type": "string",


### PR DESCRIPTION
Introduce a patch behavior for set-route action. Modules can still invoke set-route for example during module updates, without interfering with attributes previously set by user preference, like ip_allowlist.

- Relax the JSON schema to make all input attributes optional
- Read current route attributes from get_route() and use its value as default for missing attributes
- If the route is new, still enforce some checks and raise errors if minimal attributes are not given: url, host/path.

Refs  NethServer/dev#7312