### PR TITLE
fix: ensure manual_flags dir exists

### DIFF
--- a/imageroot/update-module.d/15upgrade_v3
+++ b/imageroot/update-module.d/15upgrade_v3
@@ -19,6 +19,7 @@ yaml_options = {
 }
 
 def main():
+    agent.run_helper("mkdir", "-vp", "manual_flags")
     static_cfg = yaml.safe_load(open("traefik.yaml"))
     upgrade_to_v3(static_cfg)
 


### PR DESCRIPTION
Fix a regression of Traefik 3 upgrade. The backup procedure now assumes that manual_flags directory exists because it is created by create-module action. Ensure consistent dir layout also for upgraded nodes.

Refs NethServer/dev#7353