### PR TITLE
fix(delete-certificate): output validator

### DIFF
--- a/imageroot/actions/delete-certificate/validate-output.json
+++ b/imageroot/actions/delete-certificate/validate-output.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "delete-certificate output",
+    "$id": "http://schema.nethserver.org/traefik/delete-certificate-output.json",
+    "description": "JSON schema matching anything. Placeholder, see bug NethServer/dev#7058"
+}
+


### PR DESCRIPTION
Placeholder, see bug NethServer/dev#7058

See also: https://community.nethserver.org/t/deleting-certificates-on-updated-systems-throws-an-error/25591/5?u=davidep