### PR TITLE
feat(set-route): add authResponseHeaders option

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,28 @@ api-cli run set-route --agent module/traefik1 --data - <<EOF
 }
 EOF
 ```
+
+With `forward_auth` and `auth_response_headers`
+```
+api-cli run set-route --agent module/traefik1 --data - <<EOF
+{
+  "instance": "module1",
+  "url": "http://127.0.0.1/add-module1",
+  "host": "127.0.0.1",
+  "lets_encrypt": false,
+  "http2https": false,
+  "skip_cert_verify": false,
+  "forward_auth": {
+      "address": "http://127.0.0.1:9311/api/module/module1/http-basic/add-module1",
+      "skip_tls_verify": true,
+      "auth_response_headers": [
+        "X-Auth-User",
+        "X-Auth-Group"
+      ]
+  }
+}
+EOF
+```
 ## get-route
 
 This action get an existing route. It returns a JSON object that describes the route configuration, if the

--- a/imageroot/actions/set-route/10validate_headers_name
+++ b/imageroot/actions/set-route/10validate_headers_name
@@ -17,10 +17,11 @@ agent.set_weight(os.path.basename(__file__), 0) # Validation step, no task progr
 # If parsing fails, output everything to stderr
 data = json.load(sys.stdin)
 
+field_re = re.compile(r"^((?![()<>@,;:\\\"/[\]?={}])[!-~])+$")
+
 if "headers" in data:
     req_headers= data["headers"].get('request',{})
     res_headers= data["headers"].get('response',{})
-    field_re = re.compile(r"^((?![()<>@,;:\\\"/[\]?={}])[!-~])+$")
 
     for field_name in req_headers:
         if field_re.match(field_name) is None:
@@ -32,4 +33,11 @@ if "headers" in data:
         if field_re.match(field_name) is None:
             agent.set_status('validation-failed')
             json.dump([{'field':'headers ','parameter':'response','value': field_name,'error':'headers_name_format_is_not_valid'}], fp=sys.stdout)
+            sys.exit(3)
+
+if data.get("forward_auth") and data["forward_auth"].get("auth_response_headers"):
+    for field_name in data["forward_auth"].get("auth_response_headers", {}):
+        if field_re.match(field_name) is None:
+            agent.set_status('validation-failed')
+            json.dump([{'field':'headers ','parameter':'auth_response_headers','value': field_name,'error':'headers_name_format_is_not_valid'}], fp=sys.stdout)
             sys.exit(3)

--- a/imageroot/actions/set-route/20writeconfig
+++ b/imageroot/actions/set-route/20writeconfig
@@ -130,6 +130,10 @@ if data.get('user_created') is not None and data["user_created"] is True:
 # Setup forward route
 if data.get("forward_auth"):
     middlewares[f'{data["instance"]}-auth'] = { "forwardAuth": {"address": data["forward_auth"]["address"], "tls": { "insecureSkipVerify": data["forward_auth"].get("skip_tls_verify", False) }}}
+    if data["forward_auth"].get("auth_response_headers"):
+        middlewares[f'{data["instance"]}-auth']["forwardAuth"]["authResponseHeaders"] = data["forward_auth"]["auth_response_headers"]
+    else:
+        middlewares[f'{data["instance"]}-auth']["forwardAuth"].pop('authResponseHeaders', None)
     router_http["middlewares"].append(f'{data["instance"]}-auth')
     router_https["middlewares"].append(f'{data["instance"]}-auth')
 

--- a/imageroot/actions/set-route/validate-input.json
+++ b/imageroot/actions/set-route/validate-input.json
@@ -53,7 +53,10 @@
             "http2https": true,
             "forward_auth": {
                 "address": "http://127.0.0.1:9311/module/mod1/http-basic/action-fake",
-                "skip_tls_verify": true
+                "skip_tls_verify": true,
+                "auth_response_headers": [
+                    "X-Auth-User"
+                ]
             }
         }
     ],


### PR DESCRIPTION
Allow to forward headers from the remote authentication server: this is used by Grafana to integrate with cluster-admin auth