### PR TITLE
feat: validate FQDN against HTTP routes

### DIFF
--- a/imageroot/actions/set-certificate/05check_routes
+++ b/imageroot/actions/set-certificate/05check_routes
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+import json
+import sys
+import os
+import agent
+import subprocess
+
+agent.set_weight(os.path.basename(__file__), 0) # Validation step, no task progress at all
+
+
+
+def main():
+    request = json.load(sys.stdin)
+    if request.get('check_routes', False) and is_fqdn_used_by_route(request['fqdn']):
+        agent.set_status('validation-failed')
+        json.dump([{'field':'fqdn','parameter':'fqdn','value': request['fqdn'],'error':'fqdn_conflicts_with_route'}], fp=sys.stdout)
+        sys.exit(2)
+
+def is_fqdn_used_by_route(fqdn):
+    proc = subprocess.run(["../actions/list-routes/20readconfig"], input=json.dumps({"expand_list": True}), text=True, stdout=subprocess.PIPE)
+    for route in json.loads(proc.stdout):
+        if not route.get('lets_encrypt'):
+            continue
+        if fqdn == route.get('host'):
+            print(f"[ERROR] Validation failed: fqdn {fqdn} conflicts with HTTP route {route['instance']}", file=sys.stderr)
+            return True
+    return False
+
+if __name__ == "__main__":
+    main()

--- a/imageroot/actions/set-certificate/validate-input.json
+++ b/imageroot/actions/set-certificate/validate-input.json
@@ -9,6 +9,10 @@
         },
         {
             "fqdn": "example.com",
+            "check_routes": true
+        },
+        {
+            "fqdn": "example.com",
             "sync_timeout": 10
         }
     ],
@@ -17,6 +21,11 @@
         "fqdn"
     ],
     "properties": {
+        "check_routes": {
+            "type":"boolean",
+            "default": false,
+            "description": "If true, check the fqdn is not used by an HTTP route with Let's Encrypt flag set"
+        },
         "fqdn": {
             "description": "A fully qualified domain name, or a wildcard name pattern",
             "type": "string",


### PR DESCRIPTION
Prevent the usage of a FQDN among the node default certificate SAN, if the FQDN is already used by one or more HTTP routes with Let's Encrypt certificate.

Duplicating server names in HTTP routes and TLS Certificates page leads to performance and configuration issues, we want to avoid them.

Refs NethServer/dev#7383

See also https://github.com/NethServer/ns8-core/pull/885