### PR TITLE
fix(upload-certificate): add a trailing line to uploaded certs when is missing

### DIFF
--- a/imageroot/actions/upload-certificate/22save_certificates
+++ b/imageroot/actions/upload-certificate/22save_certificates
@@ -9,8 +9,12 @@ set -e
 
 ensure_final_newline() {
   local file="$1"
-  # If the last character is not a newline, append one
-  [ "$(tail -c1 "$file")" ] && printf '\n' >> "$file"
+  # Get last character
+  last_char=$(tail -c1 "$file")
+  # Check if last char is not a newline
+  if [ "$last_char" != "" ] && [ "$last_char" != $'\n' ]; then
+    printf '\n' >> "$file"
+  fi
 }
 
 CERT_FILE=uploaded_cert


### PR DESCRIPTION
This pull request introduces a utility function to ensure uploaded certificates and keys have a trailing newline, improving compatibility and preventing potential issues with file processing. The function is integrated into the certificate upload script.

https://github.com/NethServer/dev/issues/7526