### PR TITLE
fix(set-route): allow switch between host and path

### DIFF
--- a/imageroot/actions/set-route/11validate_host
+++ b/imageroot/actions/set-route/11validate_host
@@ -16,7 +16,7 @@ agent.set_weight(os.path.basename(__file__), 0) # Validation step, no task progr
 # If parsing fails, output everything to stderr
 data = json.load(sys.stdin)
 
-if "host" in data and "path" not in data:
+if "host" in data and not data.get('path'):
     if data["host"] == '127.0.0.1' or data["host"] == 'localhost':
         agent.set_status('validation-failed')
         json.dump([{'field':'host','parameter':'host','value': data["host"],'error':'host_is_not_valid_not_localhost'}], fp=sys.stdout)

--- a/imageroot/actions/set-route/validate-input.json
+++ b/imageroot/actions/set-route/validate-input.json
@@ -12,6 +12,14 @@
             "http2https": true
         },
         {
+            "instance": "module1",
+            "url": "http://127.0.0.0:2000",
+            "host": "module.example.org",
+            "path": null,
+            "lets_encrypt": true,
+            "http2https": true
+        },
+        {
             "instance": "module2",
             "url": "http://127.0.0.0:2000",
             "host": "module.example.org",
@@ -23,6 +31,14 @@
             "instance": "module3",
             "url": "http://127.0.0.0:2000",
             "path": "/foo",
+            "lets_encrypt": true,
+            "http2https": true
+        },
+        {
+            "instance": "module3",
+            "url": "http://127.0.0.0:2000",
+            "path": "/foo",
+            "host": null,
             "lets_encrypt": true,
             "http2https": true
         },
@@ -81,17 +97,23 @@
             "description": "The backend target URL."
         },
         "host": {
-            "type": "string",
+            "type": [
+                "string",
+                "null"
+            ],
             "format": "hostname",
             "pattern": "\\.",
             "title": "Virtualhost",
-            "description": "A fully qualified domain name as virtualhost."
+            "description": "A fully qualified domain name as virtualhost. NULL clears the current value."
         },
         "path": {
-            "type": "string",
+            "type": [
+                "string",
+                "null"
+            ],
             "pattern": "^/.*$",
             "title": "Request path prefix",
-            "description": "A path prefix, the matching evaluation will be performed whit and without the trailing slash, eg /foo will match `/foo and `/foo/*, also `/foo/` will match /foo and /foo/*",
+            "description": "A path prefix, the matching evaluation will be performed whit and without the trailing slash, eg /foo will match `/foo and `/foo/*, also `/foo/` will match /foo and /foo/*.  NULL clears the current value.",
             "examples": [
                 "/foo",
                 "/foo/"


### PR DESCRIPTION
Since missing input attributes do not alter the current attribute value, we allow to pass a NULL value for "host" and "path" attributes to ensure they are removed from Traefik's configuration (see the new JSON examples).

This change enables the UI to edit an existing route and changing the Host and Path fields independently.

Refs NethServer/dev#7367