### PR TITLE
fix: avoid IP exposure in TLS certificate

### DIFF
--- a/imageroot/actions/create-module/20certificate
+++ b/imageroot/actions/create-module/20certificate
@@ -23,4 +23,4 @@ if [ -e $NAME.crt ] && [ -e $NAME.key ]; then
     exit 0
 fi
 
-openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout selfsigned.key -out selfsigned.crt -subj "/CN=$FQDN"  -addext "subjectAltName=DNS:$FQDN"
+openssl req -x509 -newkey rsa:4096 -sha256 -days 3650 -nodes -keyout selfsigned.key -out selfsigned.crt -subj "/CN=$FQDN"  -addext "subjectAltName=DNS:localhost,DNS:$FQDN"


### PR DESCRIPTION
Remove IP addresses from the SAN list.

Adding an IP address as a SAN does not improve certificate validity (since it is self-signed) but does reveal network information.