### PR TITLE
feat: additional names of hosts-changed event

### DIFF
--- a/imageroot/actions/delete-route/20file
+++ b/imageroot/actions/delete-route/20file
@@ -29,6 +29,10 @@ p.unlink(missing_ok=True)
 pf = Path(f'manual_flags/{data["instance"]}')
 pf.unlink(missing_ok=True)
 
+changed_names = set()
 # Purge certificate, if it matches the route Host
 if route_host:
-    cert_helpers.purge_acme_json_and_restart_traefik(purge_names={route_host})
+    changed_names = cert_helpers.purge_acme_json_and_restart_traefik(purge_names={route_host})
+if not changed_names:
+    # Traefik was not restarted: notify hosts-changed event here:
+    cert_helpers.update_redis_hosts_key_and_notify_event()

--- a/imageroot/actions/set-route/20writeconfig
+++ b/imageroot/actions/set-route/20writeconfig
@@ -177,9 +177,14 @@ if middlewares:
 with open(f'configs/{data["instance"]}.yml', 'w') as fp:
     fp.write(yaml.safe_dump(config, default_flow_style=False, sort_keys=False, allow_unicode=True))
 
+changed_names = set()
 # If cleanup is requested, remove the original Host from acme.json:
 if (request.get("lets_encrypt_cleanup") and
     original_data.get("host") and
     data.get("lets_encrypt") == False):
     # Traefik restarts only when the original Host exists in acme.json:
-    cert_helpers.purge_acme_json_and_restart_traefik(purge_names={original_data["host"]})
+    changed_names = cert_helpers.purge_acme_json_and_restart_traefik(purge_names={original_data["host"]})
+
+if not changed_names:
+    # Traefik was not restarted: notify hosts-changed event here:
+    cert_helpers.update_redis_hosts_key_and_notify_event()

--- a/imageroot/actions/set-route/21sync_hosts
+++ b/imageroot/actions/set-route/21sync_hosts
@@ -1,10 +1,9 @@
-#!/usr/bin/env sh
+#!/bin/bash
 
 #
-# Copyright (C) 2024 Nethesis S.r.l.
+# Copyright (C) 2025 Nethesis S.r.l.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-# Call the write-hosts action to update the hosts file
-
-write-hosts || :
+# Placeholder, see bug NethServer/dev#7058
+exit 0

--- a/imageroot/bin/write-hosts
+++ b/imageroot/bin/write-hosts
@@ -1,55 +1,10 @@
 #!/usr/bin/env python3
 
 #
-# Copyright (C) 2024 Nethesis S.r.l.
+# Copyright (C) 2025 Nethesis S.r.l.
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
-"""
-This script syncs the hosts from traefik to redis.
-Allows to notify modules of the change.
-"""
+import cert_helpers
 
-import sys
-import json
-import os
-import re
-
-from urllib3.util import Retry
-from requests import Session
-from requests.adapters import HTTPAdapter
-from requests.exceptions import RequestException
-
-import agent
-
-# Fetch router list from traefik
-api_path = os.environ["API_PATH"]
-session = Session()
-retries = Retry(
-    total=8, backoff_factor=0.5, # Sum of retry periods should be 63.5 seconds
-    status_forcelist=set(range(404,512)), # retry on error states during Traefik startup
-)
-
-try:
-    session.mount('http://', HTTPAdapter(max_retries=retries))
-    response = session.get(f'http://127.0.0.1/{api_path}/api/http/routers').json()
-    session.close()
-except Exception as ex:
-    print(agent.SD_ERR, ex, file=sys.stderr)
-    sys.exit(1)
-
-# Connect to redis using module credentials
-agent_id = os.getenv("AGENT_ID")
-redis_client = agent.redis_connect(privileged=True)
-# Write pipeline to redis
-redis_pipeline = redis_client.pipeline()
-redis_pipeline.delete(f'{agent_id}/hosts')
-for route in response:
-    if 'rule' in route and 'Host' in route['rule']:
-        # Extract the hosts from the rule
-        rule_hosts = re.findall(r'Host\(`(.*?)`\)', route['rule'])
-        for host in rule_hosts:
-            redis_pipeline.sadd(f'{agent_id}/hosts', host)
-
-redis_pipeline.publish(f'{agent_id}/event/hosts-changed', json.dumps({'node_id': os.environ['NODE_ID']}))
-redis_pipeline.execute()
+cert_helpers.update_redis_hosts_key_and_notify_event()


### PR DESCRIPTION
- Include default certificate names in the `hosts-changed` event (for `set-default-certificate` and `set-certificate` actions).
- Emit the event only when the set of HTTP route hostnames actually changes, avoiding redundant notifications from `delete-route` and `set-route`.
- Suppress duplicate events during Traefik restarts.

Refs NethServer/dev#7544