### PR TITLE
feat: delete obsolete certificates

### DIFF
--- a/imageroot/actions/delete-certificate/20writeconfig
+++ b/imageroot/actions/delete-certificate/20writeconfig
@@ -19,11 +19,14 @@ def main():
         if not old_names:
             exit_certificate_not_found_error('path', request['path'])
     elif request['type'] == 'internal':
-        old_names = cert_helpers.purge_acme_json_and_restart_traefik(purge_serial=request['serial'])
-        if old_names:
-            cert_helpers.clear_certresolver_in_http_routes(old_names)
-        else:
-            exit_certificate_not_found_error('serial', request['serial'])
+        if 'serial' in request:
+            old_names = cert_helpers.purge_acme_json_and_restart_traefik(purge_serial=request['serial'])
+            if old_names:
+                cert_helpers.clear_certresolver_in_http_routes(old_names)
+            else:
+                exit_certificate_not_found_error('serial', request['serial'])
+        elif request.get('obsolete') == True:
+            old_names = cert_helpers.purge_acme_json_and_restart_traefik(purge_obsolete=True)
     json.dump({"certificate_names": list(old_names)}, fp=sys.stdout)
 
 def exit_certificate_not_found_error(parameter, value):

--- a/imageroot/actions/delete-certificate/validate-input.json
+++ b/imageroot/actions/delete-certificate/validate-input.json
@@ -2,11 +2,15 @@
     "$schema": "http://json-schema.org/draft-07/schema#",
     "title": "delete-certificate input",
     "$id": "http://schema.nethserver.org/traefik/set-certificate-input.json",
-    "description": "Delete a configured TLS certificate",
+    "description": "Delete one or more TLS certificates matching the input",
     "examples": [
         {
             "path": "custom_certificates/mycert.crt",
             "type": "custom"
+        },
+        {
+            "obsolete": true,
+            "type": "internal"
         },
         {
             "serial": "548155130505306540286255320287329564948959",
@@ -15,6 +19,20 @@
     ],
     "type": "object",
     "oneOf": [
+        {
+            "required": [
+                "obsolete",
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "const": "internal"
+                },
+                "obsolete": {
+                    "const": true
+                }
+            }
+        },
         {
             "required": [
                 "serial",
@@ -43,10 +61,16 @@
             "type": "string",
             "description": "Identify where the certificate is stored: internal (acme.json), custom (uploaded)"
         },
+        "obsolete": {
+            "description": "Delete any internal certificate marked as obsolete",
+            "type": "boolean"
+        },
         "serial": {
+            "description": "Delete the internal certificate with the given serial number",
             "type": "string"
         },
         "path": {
+            "description": "Delete the uploaded certificate with the given filesystem path",
             "type": "string"
         }
     }


### PR DESCRIPTION
Delete from acme.json any certificate that is not used by Traefik configuration. That means the certificate is not used as default certificate and as HTTP route certificate.

Refs NethServer/dev#7544