### PR TITLE
fix: bad metrics endpoint on traefik1

### DIFF
--- a/imageroot/actions/create-module/80provision_metrics
+++ b/imageroot/actions/create-module/80provision_metrics
@@ -16,7 +16,7 @@ node_id = int(os.environ['NODE_ID'])
 def main():
     global module_id, node_id
     rdb_ro = agent.redis_connect()
-    ip_address = rdb_ro.hget(f'node/{node_id}/vpn', 'ip_address')
+    ip_address = rdb_ro.hget(f'node/{node_id}/vpn', 'ip_address') or '127.0.0.1'
     targets = [{
         "targets": [f"{ip_address}:8082"],
         "labels": {

--- a/imageroot/events/vpn-changed/10fix_metrics_endpoint
+++ b/imageroot/events/vpn-changed/10fix_metrics_endpoint
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+#
+# Copyright (C) 2025 Nethesis S.r.l.
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+# The "traefik1" instance was installed when VPN IP address was undefined,
+# before the "create-cluster" action run. Here we replace the fallback
+# value 127.0.0.1 with the correct VPN IP address, to fix Prometheus
+# scrape endpoint configuration.
+
+if [[ ${MODULE_ID} == traefik1 ]] &&
+    redis-exec hget module/traefik1/metrics_targets traefik | grep -q -F 127.0.0.1 ; then
+    # Run at most one time:
+    exec ../actions/create-module/80provision_metrics
+fi


### PR DESCRIPTION
This PR fixes two issues:

1. (main issue) bad Prometheus endpoint configuration for traefik1
2. wrong name of Prometheus label "node_id"

Main issue:

The VPN IP address is not defined when traefik1 is installed by install.sh. The VPN IP is defined later, by action `create-cluster`.

Solution:

1. Use 127.0.0.1 as fallback value if VPN IP address is not defined. 
3. On `vpn-changed` event (and VPN IP address is defined), replace 127.0.0.1 with the correct IP.

Refs NethServer/dev#7544