### PR TITLE
Add `set-default-certificate` action to roles and enhance tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ roles are omitted.
 | `delete-route` | routeadm, fulladm |
 | `list-routes` | routeadm, fulladm |
 | `set-certificate` | certadm, fulladm |
+| `set-default-certificate` | certadm, fulladm |
 | `get-certificate` | certadm, fulladm |
 | `delete-certificate` | certadm, fulladm |
 | `list-certificates` | certadm, fulladm |

--- a/imageroot/actions/create-module/30grants
+++ b/imageroot/actions/create-module/30grants
@@ -25,6 +25,7 @@ redis-exec SADD "${AGENT_ID}/roles/routeadm" "${routeadm_actions[@]}"
 certadm_actions=(
     delete-certificate
     set-certificate
+    set-default-certificate
     get-certificate
     list-certificates
 )

--- a/tests/20_traefik_certificates_api.robot
+++ b/tests/20_traefik_certificates_api.robot
@@ -17,13 +17,22 @@ Get configured ACME server
     ${response} =  Run task    module/${MID}/get-acme-server    {}
     Should Be Equal As Strings    ${response['url']}        https://acme-staging-v02.api.letsencrypt.org/directory
 
-Request an invalid certificate
+Request an invalid certificate with set-certificate
     ${response} =  Run task    module/${MID}/set-certificate
     ...    {"fqdn":"example.com"}    rc_expected=2
     Should Be Equal As Strings    ${response['obtained']}    False
 
-Get invalid certificate status
+Get invalid certificate status obtained by set-certificate
     ${response} =  Run task    module/${MID}/get-certificate    {"fqdn": "example.com"}
+    Should Be Equal As Strings    ${response['type']}    selfsigned
+
+Request an invalid certificate with set-default-certificate
+    ${response} =  Run task    module/${MID}/set-default-certificate
+    ...    {"fqdn":"example2.com"}    rc_expected=2
+    Should Be Equal As Strings    ${response['obtained']}    False
+
+Get invalid certificate status obtained by set-default-certificate
+    ${response} =  Run task    module/${MID}/get-certificate    {"fqdn": "example2.com"}
     Should Be Equal As Strings    ${response['type']}    selfsigned
 
 Get certificate list


### PR DESCRIPTION
Include the `set-default-certificate` action in the roles table and ensure it is part of the certadm and fulladm roles. Enhance tests to cover invalid certificate requests using the new action.

https://github.com/NethServer/dev/issues/7669