### PR TITLE
fix(systemd): replace %S with %E in unit files

### DIFF
--- a/imageroot/systemd/user/certificate-exporter.path
+++ b/imageroot/systemd/user/certificate-exporter.path
@@ -2,5 +2,5 @@
 Description=Monitor acme.json file for changes
 
 [Path]
-PathChanged=%S/state/acme/acme.json
+PathChanged=%E/state/acme/acme.json
 Unit=certificate-exporter.service

--- a/imageroot/systemd/user/traefik.service
+++ b/imageroot/systemd/user/traefik.service
@@ -4,7 +4,7 @@ Wants=certificate-exporter.path
 
 [Service]
 Environment=PODMAN_SYSTEMD_UNIT=%n
-EnvironmentFile=%S/state/environment
+EnvironmentFile=%E/state/environment
 Restart=always
 ExecStartPre=/bin/rm -f %t/traefik.pid %t/traefik.ctr-id configs/_validation*.yml
 ExecStart=/usr/bin/podman run \
@@ -28,7 +28,7 @@ ExecStop=/usr/bin/podman stop --ignore --cidfile %t/traefik.ctr-id -t 15
 ExecStopPost=/usr/bin/podman rm --ignore -f --cidfile %t/traefik.ctr-id
 PIDFile=%t/traefik.pid
 Type=forking
-WorkingDirectory=%S/state
+WorkingDirectory=%E/state
 SyslogIdentifier=%u
 
 [Install]


### PR DESCRIPTION
## Summary
- Newer systemd releases (Rocky Linux 9.8+, Debian 13) changed the `%S` specifier to expand to `~/.local/state` instead of `~/.config`, breaking units that relied on the old behavior to reference the config/state directory.
- Replaced `%S` with `%E` across all affected systemd user unit files. `%E` expands to `~/.config` on both old and new systemd, making the units forward-compatible.

Related: NethServer/dev#8029

## Test plan
- [ ] Verify units still parse (`systemd-analyze verify`) on a test node
- [ ] Confirm services start correctly on both an old (Rocky 9.x pre-9.8) and new (Rocky 9.8+/Debian 13) systemd host